### PR TITLE
base_context processing and processed logging methods

### DIFF
--- a/lib/puppet/resource_api/base_context.rb
+++ b/lib/puppet/resource_api/base_context.rb
@@ -50,15 +50,16 @@ class Puppet::ResourceApi::BaseContext
     end
   end
 
-  def processing(titles, is, should, message: 'Processing')
+  def processing(title, is, should, message: 'Processing')
+    raise "#{__method__} only accepts a single resource title" if title.respond_to?(:each)
     start_time = Time.now
-    setup_context(titles, message)
+    setup_context(title, message)
     begin
-      debug("Starting processing of #{titles} from #{is} to #{should}")
+      debug("Starting processing of #{title} from #{is} to #{should}")
       yield
-      notice("Finished processing #{titles} in #{format_seconds(Time.now - start_time)} seconds: #{should}")
+      notice("Finished processing #{title} in #{format_seconds(Time.now - start_time)} seconds: #{should}")
     rescue StandardError => e
-      err("Failed processing #{titles} after #{format_seconds(Time.now - start_time)} seconds: #{e}")
+      err("Failed processing #{title} after #{format_seconds(Time.now - start_time)} seconds: #{e}")
       raise
     ensure
       @context = nil
@@ -69,6 +70,11 @@ class Puppet::ResourceApi::BaseContext
     define_method(method) do |titles, message: method.to_s.capitalize|
       notice("#{message}: #{titles}")
     end
+  end
+
+  def processed(title, is, should)
+    raise "#{__method__} only accepts a single resource title" if title.respond_to?(:each)
+    notice("Processed #{title} from #{is} to #{should}")
   end
 
   def attribute_changed(title, attribute, is, should, message: nil)

--- a/spec/puppet/resource_api/base_context_spec.rb
+++ b/spec/puppet/resource_api/base_context_spec.rb
@@ -208,7 +208,22 @@ RSpec.describe Puppet::ResourceApi::BaseContext do
     end
   end
 
-  describe '#processing(titles, is, should, message: \'Processing\', &block)' do
+  describe '#processed(title, is, should)' do
+    it 'logs the successful change of attributes' do
+      expect(context).to receive(:send_log).with(:notice, %r{Processed Thing\[one\] from {:ensure=>:absent} to {:ensure=>:present, :name=>\"thing one\"}})
+      context.processed('Thing[one]', { ensure: :absent }, { ensure: :present, name: 'thing one' })
+    end
+
+    it 'raises if multiple titles are passed' do
+      expect { context.processed(['Thing[one]', 'Thing[two'], { foo: 'bar' }, { foo: 'baz' })  }.to raise_error('processed only accepts a single resource title')
+    end
+  end
+
+  describe '#processing(title, is, should, message: \'Processing\', &block)' do
+    it 'raises if multiple titles are passed' do
+      expect { context.processing(['Thing[one]', 'Thing[two'], { foo: 'bar' }, { foo: 'baz' }) { puts 'Doing it' } }.to raise_error('processing only accepts a single resource title')
+    end
+
     it 'logs the start message' do
       allow(context).to receive(:send_log)
       expect(context).to receive(:send_log).with(:debug, %r{starting processing of.*some_title.*}i)


### PR DESCRIPTION
Adds processed()
Updates processing() to only accept a single resource title, and to raise if multiple are passed.