### PR TITLE
(main) Fixup to_manifest output

### DIFF
--- a/lib/puppet/resource_api/glue.rb
+++ b/lib/puppet/resource_api/glue.rb
@@ -41,7 +41,7 @@ module Puppet::ResourceApi
     end
 
     def to_manifest
-      (["#{@typename} { #{values[:name].inspect}: "] + values.keys.reject { |k| k == :name }.map { |k| "  #{k} => #{values[k].inspect}," } + ['}']).join("\n")
+      (["#{@typename} { #{values[:name].inspect}: "] + values.keys.reject { |k| k == :name }.map { |k| "  #{k} => #{Puppet::Parameter.format_value_for_display(values[k])}," } + ['}']).join("\n")
     end
 
     # Convert our resource to yaml for Hiera purposes.

--- a/spec/puppet/resource_api/glue_spec.rb
+++ b/spec/puppet/resource_api/glue_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+# The tests in here are only a light dusting to avoid accidents,
+# but for serious testing, these need to go through a full
+# `puppet resource` read/write cycle to ensure that there is nothing
+# funky happening with new puppet versions.
+RSpec.describe 'the dirty bits' do
+  describe Puppet::ResourceApi::TypeShim do
+    subject(:instance) { described_class.new('title', { attr: 'value' }, 'typename') }
+
+    describe '.values' do
+      it { expect(instance.values).to eq(name: 'title', attr: 'value') }
+    end
+
+    describe '.typename' do
+      it { expect(instance.typename).to eq 'typename' }
+    end
+
+    describe '.name' do
+      it { expect(instance.name).to eq 'title' }
+    end
+
+    describe '.to_resource' do
+      it { expect(instance.to_resource).to be_a Puppet::ResourceApi::ResourceShim }
+      describe '.values' do
+        it { expect(instance.to_resource.values).to eq(name: 'title', attr: 'value') }
+      end
+
+      describe '.typename' do
+        it { expect(instance.to_resource.typename).to eq 'typename' }
+      end
+    end
+  end
+
+  describe Puppet::ResourceApi::ResourceShim do
+    subject(:instance) { described_class.new({ name: 'title', attr: 'value' }, 'typename') }
+
+    describe '.values' do
+      it { expect(instance.values).to eq(name: 'title', attr: 'value') }
+    end
+
+    describe '.typename' do
+      it { expect(instance.typename).to eq 'typename' }
+    end
+
+    describe '.title' do
+      it { expect(instance.title).to eq 'title' }
+    end
+
+    describe '.prune_parameters(*_args)' do
+      it { expect(instance.prune_parameters).to eq instance }
+    end
+
+    describe '.to_manifest' do
+      it { expect(instance.to_manifest).to eq "typename { \"title\": \n  attr => 'value',\n}" }
+    end
+
+    describe '.to_hierayaml' do
+      it { expect(instance.to_hierayaml).to eq "  title: \n    attr: 'value'\n" }
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit resource output was improperly formatted

```
ntp_server { "1.2.3.4":
  ensure => ':present',
  key => '"94"',
  minpoll => '"4"',
  maxpoll => '"14"',
  prefer => 'true',
  source_interface => '"Vlan1"',
}
```
vs
```
ntp_server { "1.2.3.4":
  ensure => 'present',
  key => '94',
  minpoll => '4',
  maxpoll => '14',
  prefer => true,
  source_interface => 'Vlan1',
}
```