### PR TITLE
(PDK-536) Proper datatype parsing and checking

### DIFF
--- a/spec/acceptance/device_spec.rb
+++ b/spec/acceptance/device_spec.rb
@@ -9,11 +9,7 @@ RSpec.describe 'exercising a device provider' do
   describe 'using `puppet resource`' do
     it 'reads resources from the target system' do
       stdout_str, status = Open3.capture2e("puppet resource #{common_args} device_provider")
-      if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.4')
-        expect(stdout_str.strip).to eq 'DL is deprecated, please use Fiddle'
-      else
-        expect(stdout_str.strip).to be_empty
-      end
+      expect(stdout_str.strip).to match %r{\A()|(DL is deprecated, please use Fiddle)\Z}
       expect(status).to eq 0
     end
     it 'manages resources on the target system' do


### PR DESCRIPTION
This uses Puppet4+ pops to parse and check datatypes. This allows types
to use the full range of expressibility when declaring attributes.