### PR TITLE
SimpleProvider: fix `is`-lookup and docs

### DIFF
--- a/lib/puppet/resource_api/simple_provider.rb
+++ b/lib/puppet/resource_api/simple_provider.rb
@@ -2,11 +2,12 @@ module Puppet::ResourceApi
   # This class provides a default implementation for set(), when your resource does not benefit from batching.
   # Instead of processing changes yourself, the `create`, `update`, and `delete` functions, are called for you,
   # with proper logging already set up.
-  # Note that your type needs to use `ensure` in the conventional way to signal presence and absence of resources.
+  # Note that your type needs to use `name` as its namevar, and `ensure` in the conventional way to signal presence
+  # and absence of resources.
   class SimpleProvider
     def set(context, changes)
       changes.each do |name, change|
-        is = change.key?(:is) ? change[:is] : (get(context) || []).find { |key| key[:id] == name }
+        is = change.key?(:is) ? change[:is] : (get(context) || []).find { |r| r[:name] == name }
         should = change[:should]
 
         is = { name: name, ensure: 'absent' } if is.nil?


### PR DESCRIPTION
Previously when no `is` value was passed to set, the lookup for the
cached values would have gone wrong. This commit now properly checks
for `name`, and calls this out in the docs, too.