### PR TITLE
(PDK-513) implement `supports_noop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ There are still a few notable gaps between the implementation and the specificat
 * Only a single runtime environment (the Puppet commands) is currently implemented.
 * `auto*` definitions.
 
+Restrictions of running under puppet:
+* `supports_noop` is not effective, as puppet doesn't call into the type under noop.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/spec/acceptance/noop_spec.rb
+++ b/spec/acceptance/noop_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+require 'open3'
+require 'tempfile'
+
+RSpec.describe 'exercising noop' do
+  let(:common_args) { '--verbose --trace --modulepath spec/fixtures' }
+
+  describe 'using `puppet resource`' do
+    it 'is setup correctly' do
+      stdout_str, status = Open3.capture2e("puppet resource #{common_args} test_noop_support")
+      expect(stdout_str.strip).to match %r{^test_noop_support}
+      expect(status).to eq 0
+    end
+
+    it 'executes a change' do
+      stdout_str, status = Open3.capture2e("puppet resource #{common_args} test_noop_support foo ensure=absent")
+      expect(stdout_str.strip).to match %r{noop: false}
+      expect(status).to eq 0
+    end
+
+    it 'respects --noop' do
+      pending 'puppet does not call flush() to trigger execution'
+      stdout_str, status = Open3.capture2e("puppet resource #{common_args} --noop test_noop_support foo ensure=absent")
+      expect(stdout_str.strip).to match %r{noop: true}
+      expect(status).to eq 0
+    end
+  end
+end

--- a/spec/fixtures/test_module/lib/puppet/provider/test_noop_support/test_noop_support.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/test_noop_support/test_noop_support.rb
@@ -1,0 +1,30 @@
+require 'puppet/resource_api'
+require 'puppet/resource_api/simple_provider'
+
+# Implementation for the test_noop_support type using the Resource API.
+class Puppet::Provider::TestNoopSupport::TestNoopSupport < Puppet::ResourceApi::SimpleProvider
+  def get(_context)
+    [
+      {
+        name: 'foo',
+        ensure: :present,
+      },
+      {
+        name: 'bar',
+        ensure: :present,
+      },
+    ]
+  end
+
+  def create(context, name, should)
+    context.notice("Creating '#{name}' with #{should.inspect}")
+  end
+
+  def update(context, name, should)
+    context.notice("Updating '#{name}' with #{should.inspect}")
+  end
+
+  def delete(context, name)
+    context.notice("Deleting '#{name}'")
+  end
+end

--- a/spec/fixtures/test_module/lib/puppet/provider/test_noop_support/test_noop_support.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/test_noop_support/test_noop_support.rb
@@ -2,7 +2,7 @@ require 'puppet/resource_api'
 require 'puppet/resource_api/simple_provider'
 
 # Implementation for the test_noop_support type using the Resource API.
-class Puppet::Provider::TestNoopSupport::TestNoopSupport < Puppet::ResourceApi::SimpleProvider
+class Puppet::Provider::TestNoopSupport::TestNoopSupport
   def get(_context)
     [
       {
@@ -16,15 +16,8 @@ class Puppet::Provider::TestNoopSupport::TestNoopSupport < Puppet::ResourceApi::
     ]
   end
 
-  def create(context, name, should)
-    context.notice("Creating '#{name}' with #{should.inspect}")
-  end
-
-  def update(context, name, should)
-    context.notice("Updating '#{name}' with #{should.inspect}")
-  end
-
-  def delete(context, name)
-    context.notice("Deleting '#{name}'")
+  def set(context, changes, noop: false)
+    context.notice("noop: #{noop}")
+    context.notice("inspect: #{changes.inspect}")
   end
 end

--- a/spec/fixtures/test_module/lib/puppet/type/test_noop_support.rb
+++ b/spec/fixtures/test_module/lib/puppet/type/test_noop_support.rb
@@ -1,0 +1,21 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'test_noop_support',
+  docs: <<-EOS,
+      This type provides Puppet with the capabilities to manage ...
+    EOS
+  features: [],
+  attributes:   {
+    ensure:      {
+      type:    'Enum[present, absent]',
+      desc:    'Whether this resource should be present or absent on the target system.',
+      default: 'present',
+    },
+    name:        {
+      type:      'String',
+      desc:      'The name of the resource you want to manage.',
+      behaviour: :namevar,
+    },
+  },
+)

--- a/spec/fixtures/test_module/lib/puppet/type/test_noop_support.rb
+++ b/spec/fixtures/test_module/lib/puppet/type/test_noop_support.rb
@@ -5,7 +5,7 @@ Puppet::ResourceApi.register_type(
   docs: <<-EOS,
       This type provides Puppet with the capabilities to manage ...
     EOS
-  features: [],
+  features: ['supports_noop'],
   attributes:   {
     ensure:      {
       type:    'Enum[present, absent]',

--- a/spec/fixtures/test_module/spec/unit/puppet/provider/test_noop_support/test_noop_support_spec.rb
+++ b/spec/fixtures/test_module/spec/unit/puppet/provider/test_noop_support/test_noop_support_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+# TODO: needs some cleanup/helper to avoid this misery
+module Puppet::Provider::TestNoopSupport; end
+require 'puppet/provider/test_noop_support/test_noop_support'
+
+RSpec.describe Puppet::Provider::TestNoopSupport::TestNoopSupport do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+
+  describe '#get' do
+    it 'processes resources' do
+      expect(provider.get(context)).to eq [
+        {
+          name: 'foo',
+          ensure: :present,
+        },
+        {
+          name: 'bar',
+          ensure: :present,
+        },
+      ]
+    end
+  end
+
+  describe 'create(context, name, should)' do
+    it 'creates the resource' do
+      expect(context).to receive(:notice).with(%r{\ACreating 'a'})
+
+      provider.create(context, 'a', name: 'a', ensure: 'present')
+    end
+  end
+
+  describe 'update(context, name, should)' do
+    it 'updates the resource' do
+      expect(context).to receive(:notice).with(%r{\AUpdating 'foo'})
+
+      provider.update(context, 'foo', name: 'foo', ensure: 'present')
+    end
+  end
+
+  describe 'delete(context, name, should)' do
+    it 'deletes the resource' do
+      expect(context).to receive(:notice).with(%r{\ADeleting 'foo'})
+
+      provider.delete(context, 'foo')
+    end
+  end
+end


### PR DESCRIPTION
See https://github.com/DavidS/puppet-specifications/blob/resourceapi/language/resource-api/README.md#provider-feature-supports_noop for a definition of the feature.

This commit only contains the expected outline of the tests, to structure
what needs to be done.