### PR TITLE
(PDK-919) Workaround PUP-2368 "using booleans result in unmanaged pro…

### DIFF
--- a/spec/acceptance/boolean_spec.rb
+++ b/spec/acceptance/boolean_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'tempfile'
+
+RSpec.describe 'a provider using booleans' do
+  let(:common_args) { '--verbose --trace --strict=error --modulepath spec/fixtures' }
+
+  describe 'using `puppet apply`' do
+    it 'applies a catalog with no changes' do
+      stdout_str, _status = Open3.capture2e("puppet apply #{common_args} -e \"test_bool { foo: test_bool => true, test_bool_param => true; bar: test_bool => false, test_bool_param => false }\"")
+      expect(stdout_str).not_to match %r{Updating|ensure|test_bool}i
+      expect(stdout_str).not_to match %r{Error:}
+    end
+    it 'applies a catalog with bool changes' do
+      stdout_str, _status = Open3.capture2e("puppet apply #{common_args} -e \"test_bool { foo: test_bool => false, test_bool_param => false; bar: test_bool => true, test_bool_param => true }\"")
+      expect(stdout_str).to match %r{Test_bool\[foo\]/test_bool: test_bool changed (true|'true') to 'false'}
+      expect(stdout_str).to match %r{Test_bool\[bar\]/test_bool: test_bool changed (false|'false') to 'true'}
+      expect(stdout_str).to match %r{Updating: Updating 'foo' with \{:name=>"foo", :test_bool=>false, :test_bool_param=>false, :ensure=>"present"\}}
+      expect(stdout_str).to match %r{Updating: Updating 'bar' with \{:name=>"bar", :test_bool=>true, :test_bool_param=>true, :ensure=>"present"\}}
+      expect(stdout_str).not_to match %r{Error:}
+    end
+  end
+end

--- a/spec/fixtures/test_module/lib/puppet/provider/test_bool/test_bool.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/test_bool/test_bool.rb
@@ -1,0 +1,34 @@
+require 'puppet/resource_api'
+require 'puppet/resource_api/simple_provider'
+
+# Implementation for the test_bool type using the Resource API.
+class Puppet::Provider::TestBool::TestBool < Puppet::ResourceApi::SimpleProvider
+  def get(_context)
+    [
+      {
+        name: 'foo',
+        ensure: 'present',
+        test_bool: true,
+        test_bool_param: true,
+      },
+      {
+        name: 'bar',
+        ensure: 'present',
+        test_bool: false,
+        test_bool_param: false,
+      },
+    ]
+  end
+
+  def create(context, name, should)
+    context.notice("Creating '#{name}' with #{should.inspect}")
+  end
+
+  def update(context, name, should)
+    context.notice("Updating '#{name}' with #{should.inspect}")
+  end
+
+  def delete(context, name)
+    context.notice("Deleting '#{name}'")
+  end
+end

--- a/spec/fixtures/test_module/lib/puppet/type/test_bool.rb
+++ b/spec/fixtures/test_module/lib/puppet/type/test_bool.rb
@@ -1,0 +1,30 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'test_bool',
+  docs: <<-EOS,
+      This type provides Puppet with the capabilities to manage ...
+    EOS
+  features: [],
+  attributes:   {
+    ensure:      {
+      type:    'Enum[present, absent]',
+      desc:    'Whether this resource should be present or absent on the target system.',
+      default: 'present',
+    },
+    name:        {
+      type:      'String',
+      desc:      'The name of the resource you want to manage.',
+      behaviour: :namevar,
+    },
+    test_bool:   {
+      type:      'Boolean',
+      desc:      'A boolean property for testing.',
+    },
+    test_bool_param: {
+      type:      'Boolean',
+      desc:      'A boolean parameter for testing.',
+      behaviour: :parameter,
+    },
+  },
+)

--- a/spec/fixtures/test_module/spec/unit/puppet/provider/test_bool/test_bool_spec.rb
+++ b/spec/fixtures/test_module/spec/unit/puppet/provider/test_bool/test_bool_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+# TODO: needs some cleanup/helper to avoid this misery
+module Puppet::Provider::TestBool; end
+require 'puppet/provider/test_bool/test_bool'
+
+RSpec.describe Puppet::Provider::TestBool::TestBool do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+
+  describe '#get' do
+    it 'processes resources' do
+      expect(provider.get(context)).to eq [
+        {
+          name: 'foo',
+          ensure: :present,
+        },
+        {
+          name: 'bar',
+          ensure: :present,
+        },
+      ]
+    end
+  end
+
+  describe 'create(context, name, should)' do
+    it 'creates the resource' do
+      expect(context).to receive(:notice).with(%r{\ACreating 'a'})
+
+      provider.create(context, 'a', name: 'a', ensure: 'present')
+    end
+  end
+
+  describe 'update(context, name, should)' do
+    it 'updates the resource' do
+      expect(context).to receive(:notice).with(%r{\AUpdating 'foo'})
+
+      provider.update(context, 'foo', name: 'foo', ensure: 'present')
+    end
+  end
+
+  describe 'delete(context, name, should)' do
+    it 'deletes the resource' do
+      expect(context).to receive(:notice).with(%r{\ADeleting 'foo'})
+
+      provider.delete(context, 'foo')
+    end
+  end
+end

--- a/spec/fixtures/test_module/spec/unit/puppet/type/test_bool_spec.rb
+++ b/spec/fixtures/test_module/spec/unit/puppet/type/test_bool_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'puppet/type/test_bool'
+
+RSpec.describe 'the test_bool type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:test_bool)).not_to be_nil
+  end
+end

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -236,41 +236,43 @@ RSpec.describe Puppet::ResourceApi do
           }
         end
 
+        # rubocop:disable Lint/BooleanSymbol
         context 'when using :true' do
-          let(:the_boolean) { :true } # rubocop:disable Lint/BooleanSymbol
+          let(:the_boolean) { :true }
 
-          it('the test_boolean value is set correctly') { expect(instance[:test_boolean]).to eq true }
+          it('the test_boolean value is set correctly') { expect(instance[:test_boolean]).to eq :true }
         end
         context 'when using :false' do
-          let(:the_boolean) { :false } # rubocop:disable Lint/BooleanSymbol
+          let(:the_boolean) { :false }
 
-          it('the test_boolean value is set correctly') { expect(instance[:test_boolean]).to eq false }
+          it('the test_boolean value is set correctly') { expect(instance[:test_boolean]).to eq :false }
         end
         context 'when using "true"' do
           let(:the_boolean) { 'true' }
 
-          it('the test_boolean value is set correctly') { expect(instance[:test_boolean]).to eq true }
+          it('the test_boolean value is set correctly') { expect(instance[:test_boolean]).to eq :true }
         end
         context 'when using "false"' do
           let(:the_boolean) { 'false' }
 
-          it('the test_boolean value is set correctly') { expect(instance[:test_boolean]).to eq false }
+          it('the test_boolean value is set correctly') { expect(instance[:test_boolean]).to eq :false }
         end
         context 'when using true' do
           let(:the_boolean) { true }
 
-          it('the test_boolean value is set correctly') { expect(instance[:test_boolean]).to eq true }
+          it('the test_boolean value is set correctly') { expect(instance[:test_boolean]).to eq :true }
         end
         context 'when using false' do
           let(:the_boolean) { false }
 
-          it('the test_boolean value is set correctly') { expect(instance[:test_boolean]).to eq false }
+          it('the test_boolean value is set correctly') { expect(instance[:test_boolean]).to eq :false }
         end
         context 'when using an unparsable value' do
           let(:the_boolean) { 'flubb' }
 
           it('the test_boolean value is set correctly') { expect { instance }.to raise_error Puppet::ResourceError, %r{test_boolean expect.* Boolean .* got String} }
         end
+        # rubocop:enable Lint/BooleanSymbol
       end
     end
   end


### PR DESCRIPTION
…perty"

By unmunging booleans into `:true` and `:false` symbols, we trick puppet
into not seeing the `false` value in the resource harness. This requires
additional juggling to make sure we don't pass that value on to the
provider.