### PR TITLE
Make ruby files individually loadable without puppet

### DIFF
--- a/lib/puppet/resource_api/base_context.rb
+++ b/lib/puppet/resource_api/base_context.rb
@@ -1,6 +1,8 @@
 require 'puppet/util'
 require 'puppet/util/network_device'
 
+module Puppet; end
+module Puppet::ResourceApi; end
 class Puppet::ResourceApi::BaseContext
   def initialize(typename)
     @typename = typename

--- a/lib/puppet/resource_api/glue.rb
+++ b/lib/puppet/resource_api/glue.rb
@@ -1,4 +1,4 @@
-
+module Puppet; end # rubocop:disable Style/Documentation
 module Puppet::ResourceApi
   # A trivial class to provide the functionality required to push data through the existing type/provider parts of puppet
   class TypeShim

--- a/lib/puppet/resource_api/simple_provider.rb
+++ b/lib/puppet/resource_api/simple_provider.rb
@@ -1,3 +1,4 @@
+module Puppet; end # rubocop:disable Style/Documentation
 module Puppet::ResourceApi
   # This class provides a default implementation for set(), when your resource does not benefit from batching.
   # Instead of processing changes yourself, the `create`, `update`, and `delete` functions, are called for you,


### PR DESCRIPTION
In some cases when puppet is not yet loaded, those files would
throw unnecessary errors. This fixes that.