### PR TITLE
Cache ~/.rvm for jruby jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,18 @@ matrix:
   include:
     - rvm: 2.4.3
       env: PUPPET_GEM_VERSION='~> 5' # 5.5
-    - rvm: jruby-1.7.26
-      env: PUPPET_GEM_VERSION='~> 5' JRUBY_OPTS="--debug"
-    - rvm: jruby-9.1.9.0
-      env: PUPPET_GEM_VERSION='~> 5' JRUBY_OPTS="--debug"
+    - env: RVM="jruby-1.7.26" PUPPET_GEM_VERSION='~> 5' JRUBY_OPTS="--debug"
+      before_cache: pushd ~/.rvm && rm -rf archives rubies/ruby-2.2.7 rubies/ruby-2.3.4 && popd
+      cache:
+        bundler: true
+        directories: ~/.rvm
+      before_install: rvm use jruby-1.7.26 --install --binary --fuzzy
+    - env: RVM="jruby-9.1.9.0" PUPPET_GEM_VERSION='~> 5' JRUBY_OPTS="--debug"
+      before_cache: pushd ~/.rvm && rm -rf archives rubies/ruby-2.2.7 rubies/ruby-2.3.4 && popd
+      cache:
+        bundler: true
+        directories: ~/.rvm
+      before_install: rvm use jruby-9.1.9.0 --install --binary --fuzzy
     - rvm: 2.4.3
       env: CHECK=rubocop
     - rvm: 2.4.3


### PR DESCRIPTION
Hey there,

I'm a Customer Support Engineer @ Travis CI and @DavidS wrote asking if it was possible to speed up the jruby jobs.

It's not great but here's my attempt. The idea is to cache the ~/.rvm directory and install jruby manually instead of using the `rvm:` key in the .travis.yml file.

Let's follow up in the e-mail you sent.