### PR TITLE
 (PDK-924) Throw when SimpleProvider is used with unensurable type

### DIFF
--- a/contrib/pre-commit
+++ b/contrib/pre-commit
@@ -2,11 +2,11 @@
 # Code modified from: https://gist.github.com/hanloong/9849098
 require 'English'
 
-ADDED_OR_MODIFIED = %r{A|AM|M|^M}
+ADDED = %r{A|AM}
 
 changed_files = `git status --porcelain`.split(%r{\n})
 changed_files = changed_files.select do |file_name_with_status|
-  file_name_with_status =~ ADDED_OR_MODIFIED
+  file_name_with_status =~ ADDED
 end
 changed_files = changed_files.map do |file_name_with_status|
   file_name_with_status.split(' ')[1]

--- a/lib/puppet/resource_api/simple_provider.rb
+++ b/lib/puppet/resource_api/simple_provider.rb
@@ -16,6 +16,8 @@ module Puppet::ResourceApi
 
         should = change[:should]
 
+        raise 'SimpleProvider cannot be used with a Type that is not ensurable' unless context.type.ensurable?
+
         is = { name: name, ensure: 'absent' } if is.nil?
         should = { name: name, ensure: 'absent' } if should.nil?
 


### PR DESCRIPTION
Also patches pre-commit hook script, so that it doesn't commit unstaged files