### PR TITLE
(PDK-996) Provide better messaging when type cannot be resolved

### DIFF
--- a/contrib/pre-commit
+++ b/contrib/pre-commit
@@ -2,15 +2,7 @@
 # Code modified from: https://gist.github.com/hanloong/9849098
 require 'English'
 
-ADDED = %r{A|AM}
-
-changed_files = `git status --porcelain`.split(%r{\n})
-changed_files = changed_files.select do |file_name_with_status|
-  file_name_with_status =~ ADDED
-end
-changed_files = changed_files.map do |file_name_with_status|
-  file_name_with_status.split(' ')[1]
-end
+changed_files = `git diff --name-only --cached --diff-filter=ACM`.split(%r{\n})
 changed_files = changed_files.select { |file_name|
   File.extname(file_name) == '.rb'
 }.join(' ')
@@ -20,4 +12,5 @@ system("bundle exec rubocop -a #{changed_files}") unless changed_files.empty?
 if $CHILD_STATUS.to_s[-1].to_i.zero? && !changed_files.empty?
   system("git add #{changed_files}")
 end
+
 exit $CHILD_STATUS.to_s[-1].to_i

--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -170,7 +170,14 @@ module Puppet::ResourceApi
             end
           end
 
-          type = Puppet::Pops::Types::TypeParser.singleton.parse(options[:type])
+          begin
+            type = Puppet::Pops::Types::TypeParser.singleton.parse(options[:type])
+          rescue Puppet::ParseErrorWithIssue => e
+            raise Puppet::DevError, "The type of the `#{name}` attribute `#{options[:type]}` could not be parsed: #{e.message}"
+          rescue Puppet::ParseError => e
+            raise Puppet::DevError, "The type of the `#{name}` attribute `#{options[:type]}` is not recognised: #{e.message}"
+          end
+
           if param_or_property == :newproperty
             define_method(:should) do
               if type.is_a? Puppet::Pops::Types::PBooleanType

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -790,6 +790,36 @@ RSpec.describe Puppet::ResourceApi do
     end
   end
 
+  context 'when registering a type with badly formed attribute type' do
+    let(:definition) do
+      {
+        name: 'bad_syntax',
+        attributes: {
+          name: {
+            type: 'Optional[String',
+          },
+        },
+      }
+    end
+
+    it { expect { described_class.register_type(definition) }.to raise_error Puppet::DevError, %r{The type of the `name` attribute `Optional\[String` could not be parsed:} }
+  end
+
+  context 'when registering a type with unknown attribute type' do
+    let(:definition) do
+      {
+        name: 'wibble',
+        attributes: {
+          name: {
+            type: 'wibble',
+          },
+        },
+      }
+    end
+
+    it { expect { described_class.register_type(definition) }.to raise_error Puppet::DevError, %r{The type of the `name` attribute `wibble` is not recognised:} }
+  end
+
   context 'when registering a namevar that is not called `name`' do
     let(:definition) do
       {


### PR DESCRIPTION
Also contains:

Better messaging when provider.get does not return correctly
(maint) Pre-commit hook should now properly deal with stages changes