### PR TITLE
Allow `SimpleDevice` to be initialized with a config hash

### DIFF
--- a/lib/puppet/util/network_device/simple/device.rb
+++ b/lib/puppet/util/network_device/simple/device.rb
@@ -6,9 +6,13 @@ module Puppet::Util::NetworkDevice::Simple
   # A basic device class, that reads its configuration from the provided URL.
   # The URL has to be a local file URL.
   class Device
-    def initialize(url, _options = {})
-      @url = URI.parse(url)
-      raise "Unexpected url '#{url}' found. Only file:/// URLs for configuration supported at the moment." unless @url.scheme == 'file'
+    def initialize(url_or_config, _options = {})
+      if url_or_config.is_a? String
+        @url = URI.parse(url_or_config)
+        raise "Unexpected url '#{url_or_config}' found. Only file:/// URLs for configuration supported at the moment." unless @url.scheme == 'file'
+      else
+        @config = url_or_config
+      end
     end
 
     def facts
@@ -16,7 +20,7 @@ module Puppet::Util::NetworkDevice::Simple
     end
 
     def config
-      raise "Trying to load config from '#{@url.path}, but file does not exist." unless File.exist? @url.path
+      raise "Trying to load config from '#{@url.path}, but file does not exist." if @url && !File.exist?(@url.path)
       @config ||= Hocon.load(@url.path, syntax: Hocon::ConfigSyntax::HOCON)
     end
   end

--- a/spec/puppet/util/network_device/simple/device_spec.rb
+++ b/spec/puppet/util/network_device/simple/device_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 require 'puppet/util/network_device/simple/device'
 
 RSpec.describe Puppet::Util::NetworkDevice::Simple::Device do
-  subject(:device) { described_class.new(url) }
+  subject(:device) { described_class.new(url_or_config) }
 
   context 'when initialized with a file:// URL' do
     context 'when the file exists' do
       let(:tempfile) { Tempfile.new('foo.txt') }
-      let(:url) { 'file://' + tempfile.path }
+      let(:url_or_config) { 'file://' + tempfile.path }
 
       before(:each) do
         tempfile.write('{ foo: bar }')
@@ -25,7 +25,7 @@ RSpec.describe Puppet::Util::NetworkDevice::Simple::Device do
     end
 
     context 'when the file does not exist' do
-      let(:url) { 'file:///tmp/foo.txt' }
+      let(:url_or_config) { 'file:///tmp/foo.txt' }
 
       it 'raises an error' do
         expect { device.config }.to raise_error RuntimeError, %r{foo\.txt.*file does not exist}
@@ -34,10 +34,18 @@ RSpec.describe Puppet::Util::NetworkDevice::Simple::Device do
   end
 
   context 'when initialized with a non-file:// URL' do
-    let(:url) { 'http://example.com/' }
+    let(:url_or_config) { 'http://example.com/' }
 
     it 'raises an error' do
       expect { device }.to raise_error RuntimeError, %r{example.com.*Only file:/// URLs for configuration supported}
+    end
+  end
+
+  context 'when initialized with a config hash' do
+    let(:url_or_config) { { key: :value } }
+
+    it 'makes the configured configuration available' do
+      expect(device.config).to eq(key: :value)
     end
   end
 end


### PR DESCRIPTION
Previously `SimpleDevice` was only looking for a credentials file to load.
This allows for tasks to re-use the same code as providers to connect to
devices.