### PR TITLE
Fix "undefined method `rs_value'" error with metaparams

### DIFF
--- a/lib/puppet/resource_api/glue.rb
+++ b/lib/puppet/resource_api/glue.rb
@@ -4,13 +4,14 @@ module Puppet; end # rubocop:disable Style/Documentation
 module Puppet::ResourceApi
   # A trivial class to provide the functionality required to push data through the existing type/provider parts of puppet
   class ResourceShim
-    attr_reader :values, :typename, :namevars, :attr_def
+    attr_reader :values, :typename, :namevars, :attr_def, :catalog
 
-    def initialize(resource_hash, typename, namevars, attr_def)
+    def initialize(resource_hash, typename, namevars, attr_def, catalog = nil)
       @values = resource_hash.dup.freeze # whatevs
       @typename = typename
       @namevars = namevars
       @attr_def = attr_def
+      @catalog = catalog
     end
 
     def title

--- a/spec/acceptance/metaparam_spec.rb
+++ b/spec/acceptance/metaparam_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+require 'open3'
+require 'tempfile'
+
+RSpec.describe 'meta parameters' do
+  let(:common_args) { '--verbose --trace --strict=error --modulepath spec/fixtures' }
+
+  describe 'using `puppet apply`' do
+    it 'are handled' do
+      output, status = Open3.capture2e("puppet apply #{common_args} -e \"include test_module::metaparam_support\"")
+      expect(output.strip).not_to match %r{warn|error}i
+      expect(status.exitstatus).to eq 0
+    end
+  end
+end

--- a/spec/acceptance/validation_spec.rb
+++ b/spec/acceptance/validation_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'validation' do
     it 'allows managing' do
       output, status = Open3.capture2e("puppet apply #{common_args} -e \"test_validation{ foo: prop => 2, param => 3 }\"")
       expect(output.strip).not_to match %r{test_validation}i
-      expect(output.strip).not_to match %r{warn|error}
+      expect(output.strip).not_to match %r{warn|error}i
       expect(status.exitstatus).to eq 0
     end
 
@@ -106,7 +106,7 @@ RSpec.describe 'validation' do
     it 'allows managing an absent instance' do
       output, status = Open3.capture2e("puppet apply #{common_args} -e \"test_validation{ gone: ensure => absent, param => 3 }\"")
       expect(output.strip).not_to match %r{test_validation}i
-      expect(output.strip).not_to match %r{warn|error}
+      expect(output.strip).not_to match %r{warn|error}i
       expect(status.exitstatus).to eq 0
     end
 

--- a/spec/fixtures/test_module/.gitignore
+++ b/spec/fixtures/test_module/.gitignore
@@ -1,3 +1,4 @@
+.git/
 .*.sw[op]
 .metadata
 .yardoc

--- a/spec/fixtures/test_module/.gitlab-ci.yml
+++ b/spec/fixtures/test_module/.gitlab-ci.yml
@@ -1,70 +1,41 @@
 ---
 stages:
-  - test_2.4.1
-  - test_2.1.9
+  - syntax
+  - unit
+
+cache:
+  paths:
+    - vendor/bundle
 
 before_script:
   - bundle -v
   - rm Gemfile.lock || true
   - gem update --system
-  - gem update bundler
   - gem --version
   - bundle -v
-  - bundle install --without system_tests
+  - bundle install --without system_tests --path vendor/bundle --jobs $(nproc)
 
-rubocop-2.4.1:
-  stage: test_2.4.1
-  image: ruby:2.4.1
+parallel_spec-Ruby 2.1.9-Puppet ~> 4.0:
+  stage: syntax
+  image: ruby:2.1.9
   script:
-    - bundle exec rake rubocop
-
-syntax-2.4.1:
-  stage: test_2.4.1
-  image: ruby:2.4.1
-  script:
-    - bundle exec rake syntax lint
-
-metadata-2.4.1:
-  stage: test_2.4.1
-  image: ruby:2.4.1
-  script:
-    - bundle exec rake metadata_lint
-
-rspec-puppet-2.4.1:
-  stage: test_2.4.1
-  image: ruby:2.4.1
+    - bundle exec rake parallel_spec
   variables:
-    PUPPET_GEM_VERSION: ~> 4.0
-    CHECK: spec
-  script:
-    - bundle update
-    - bundle exec rake $CHECK
+    PUPPET_GEM_VERSION: '~> 4.0'
 
-rubocop-2.1.9:
-  stage: test_2.1.9
-  image: ruby:2.1.9
+syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop-Ruby 2.4.4-Puppet ~> 5.5:
+  stage: syntax
+  image: ruby:2.4.4
   script:
-    - bundle exec rake rubocop
-
-syntax-2.1.9:
-  stage: test_2.1.9
-  image: ruby:2.1.9
-  script:
-    - bundle exec rake syntax lint
-
-metadata-2.1.9:
-  stage: test_2.1.9
-  image: ruby:2.1.9
-  script:
-    - bundle exec rake metadata_lint
-
-rspec-puppet-2.1.9:
-  stage: test_2.1.9
-  image: ruby:2.1.9
+    - bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
   variables:
-    PUPPET_GEM_VERSION: ~> 4.0
-    CHECK: spec
+    PUPPET_GEM_VERSION: '~> 5.5'
+
+parallel_spec-Ruby 2.4.4-Puppet ~> 5.5:
+  stage: syntax
+  image: ruby:2.4.4
   script:
-    - bundle update
-    - bundle exec rake $CHECK
+    - bundle exec rake parallel_spec
+  variables:
+    PUPPET_GEM_VERSION: '~> 5.5'
 

--- a/spec/fixtures/test_module/.pdkignore
+++ b/spec/fixtures/test_module/.pdkignore
@@ -1,3 +1,4 @@
+.git/
 .*.sw[op]
 .metadata
 .yardoc

--- a/spec/fixtures/test_module/.rubocop.yml
+++ b/spec/fixtures/test_module/.rubocop.yml
@@ -8,11 +8,14 @@ AllCops:
   Exclude:
   - bin/*
   - ".vendor/**/*"
-  - Gemfile
-  - Rakefile
+  - "**/Gemfile"
+  - "**/Rakefile"
   - pkg/**/*
   - spec/fixtures/**/*
   - vendor/**/*
+  - "**/Puppetfile"
+  - "**/Vagrantfile"
+  - "**/Guardfile"
 Metrics/LineLength:
   Description: People have wide screens, use them.
   Max: 200
@@ -65,6 +68,12 @@ Style/SymbolArray:
   EnforcedStyle: brackets
 RSpec/MessageSpies:
   EnforcedStyle: receive
+Style/Documentation:
+  Exclude:
+  - lib/puppet/parser/functions/**/*
+  - spec/**/*
+Style/WordArray:
+  EnforcedStyle: brackets
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:
@@ -72,6 +81,8 @@ Style/MethodCalledOnDoEndBlock:
 Style/StringMethods:
   Enabled: true
 Layout/EndOfLine:
+  Enabled: false
+Layout/IndentHeredoc:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false

--- a/spec/fixtures/test_module/.travis.yml
+++ b/spec/fixtures/test_module/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   - bundle -v
   - rm -f Gemfile.lock
   - gem update --system
-  - gem update bundler
   - gem --version
   - bundle -v
 script:
@@ -16,22 +15,17 @@ bundler_args: --without system_tests
 rvm:
   - 2.4.1
 env:
-  - PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
+  global:
+    - BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_GEM_VERSION="~> 5.0"
 matrix:
   fast_finish: true
   include:
     -
-      env: CHECK=rubocop
+      env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     -
-      env: CHECK="syntax lint"
+      env: CHECK=parallel_spec
     -
-      env: CHECK=metadata_lint
-    -
-      env: CHECK=release_checks
-    -
-      env: CHECK=spec
-    -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
+      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
       rvm: 2.1.9
 branches:
   only:

--- a/spec/fixtures/test_module/Gemfile
+++ b/spec/fixtures/test_module/Gemfile
@@ -33,7 +33,6 @@ group :development do
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-blacksmith", '~> 3.4',                   require: false, platforms: [:ruby]
   gem "puppet-resource_api",                           require: false
 end
 

--- a/spec/fixtures/test_module/Rakefile
+++ b/spec/fixtures/test_module/Rakefile
@@ -1,5 +1,75 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
+require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
 
-PuppetLint.configuration.send('relative')
+def changelog_user
+  return unless Rake.application.top_level_tasks.include? "changelog"
+  returnVal = nil || JSON.load(File.read('metadata.json'))['author']
+  raise "unable to find the changelog_user in .sync.yml, or the author in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator user:#{returnVal}"
+  returnVal
+end
+
+def changelog_project
+  return unless Rake.application.top_level_tasks.include? "changelog"
+  returnVal = nil || JSON.load(File.read('metadata.json'))['name']
+  raise "unable to find the changelog_project in .sync.yml or the name in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator project:#{returnVal}"
+  returnVal
+end
+
+def changelog_future_release
+  return unless Rake.application.top_level_tasks.include? "changelog"
+  returnVal = JSON.load(File.read('metadata.json'))['version']
+  raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator future_release:#{returnVal}"
+  returnVal
+end
+
+PuppetLint.configuration.send('disable_relative')
+
+if Bundler.rubygems.find_name('github_changelog_generator').any?
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
+    config.user = "#{changelog_user}"
+    config.project = "#{changelog_project}"
+    config.future_release = "#{changelog_future_release}"
+    config.exclude_labels = ['maintenance']
+    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
+    config.add_pr_wo_labels = true
+    config.issues = false
+    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
+    config.configure_sections = {
+      "Changed" => {
+        "prefix" => "### Changed",
+        "labels" => ["backwards-incompatible"],
+      },
+      "Added" => {
+        "prefix" => "### Added",
+        "labels" => ["feature", "enhancement"],
+      },
+      "Fixed" => {
+        "prefix" => "### Fixed",
+        "labels" => ["bugfix"],
+      },
+    }
+  end
+else
+  desc 'Generate a Changelog from GitHub'
+  task :changelog do
+    raise <<EOM
+The changelog tasks depends on unreleased features of the github_changelog_generator gem.
+Please manually add it to your .sync.yml for now, and run `pdk update`:
+---
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'github_changelog_generator'
+        git: 'https://github.com/skywinder/github-changelog-generator'
+        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
+EOM
+  end
+end
+

--- a/spec/fixtures/test_module/appveyor.yml
+++ b/spec/fixtures/test_module/appveyor.yml
@@ -1,3 +1,4 @@
+---
 version: 1.1.x.{build}
 skip_commits:
   message: /^\(?doc\)?.*/
@@ -12,29 +13,23 @@ environment:
   matrix:
     -
       RUBY_VERSION: 24-x64
-      CHECK: syntax lint
-    -
-      RUBY_VERSION: 24-x64
-      CHECK: metadata_lint
-    -
-      RUBY_VERSION: 24-x64
-      CHECK: rubocop
+      CHECK: syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
     -
       PUPPET_GEM_VERSION: ~> 4.0
       RUBY_VERSION: 21
-      CHECK: spec
+      CHECK: parallel_spec
     -
       PUPPET_GEM_VERSION: ~> 4.0
       RUBY_VERSION: 21-x64
-      CHECK: spec
+      CHECK: parallel_spec
     -
       PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24
-      CHECK: spec
+      CHECK: parallel_spec
     -
       PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24-x64
-      CHECK: spec
+      CHECK: parallel_spec
 matrix:
   fast_finish: true
 install:

--- a/spec/fixtures/test_module/manifests/metaparam_support.pp
+++ b/spec/fixtures/test_module/manifests/metaparam_support.pp
@@ -1,0 +1,41 @@
+# Test all metaparameters from https://puppet.com/docs/puppet/5.5/metaparameter.html with a resource API type,
+# to ensure that there are no hidden breakages.
+#
+# @summary A short summary of the purpose of this class
+#
+# @example
+#   include test_module::metaparam_support
+class test_module::metaparam_support {
+  notify { [a,b,c,d]: }
+
+  schedule { 'everyday':
+    period => daily,
+    range  => '2-4'
+  }
+
+  test_bool { 'foo':
+    test_bool       => true,
+    test_bool_param => true,
+    # provider => no parameter named 'provider'
+    alias           => 'bar',
+    audit           => all,
+    before          => Notify['a'],
+    # consume => not supported for resources
+    # export => not supported for resources
+    loglevel        => crit,
+    noop            => false,
+    notify          => Notify['b'],
+    require         => Notify['c'],
+    schedule        => 'everyday',
+    # stage => Only classes can set 'stage'; normal resources like Test_bool[f] cannot change run stage
+    subscribe       => Notify['d'],
+    tag             => [a,b,c],
+  }
+
+  @test_bool { 'virtual':
+    test_bool       => true,
+    test_bool_param => true,
+  }
+
+  Test_bool<||>
+}

--- a/spec/fixtures/test_module/metadata.json
+++ b/spec/fixtures/test_module/metadata.json
@@ -22,7 +22,7 @@
       "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ],
-  "pdk-version": "1.5.0",
+  "pdk-version": "1.7.0.pre (9)",
   "template-url": "file:///opt/puppetlabs/pdk/share/cache/pdk-templates.git",
-  "template-ref": "1.5.0-0-gd1b3eca"
+  "template-ref": "heads/master-0-gc87eee3"
 }

--- a/spec/fixtures/test_module/spec/classes/metaparam_support_spec.rb
+++ b/spec/fixtures/test_module/spec/classes/metaparam_support_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'test_module::metaparam_support' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/fixtures/test_module/spec/spec_helper.rb
+++ b/spec/fixtures/test_module/spec/spec_helper.rb
@@ -37,3 +37,12 @@ RSpec.configure do |c|
     Puppet.settings[:strict] = :error
   end
 end
+
+def ensure_module_defined(module_name)
+  module_name.split('::').reduce(Object) do |last_module, next_module|
+    last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module)
+    last_module.const_get(next_module)
+  end
+end
+
+# 'spec_overrides' from sync.yml will appear below this line

--- a/spec/fixtures/test_module/spec/unit/puppet/provider/test_noop_support/test_noop_support_spec.rb
+++ b/spec/fixtures/test_module/spec/unit/puppet/provider/test_noop_support/test_noop_support_spec.rb
@@ -24,27 +24,22 @@ RSpec.describe Puppet::Provider::TestNoopSupport::TestNoopSupport do
     end
   end
 
-  describe 'create(context, name, should)' do
-    it 'creates the resource' do
-      expect(context).to receive(:notice).with(%r{\ACreating 'a'})
+  describe '#set' do
+    context 'with noop: false' do
+      it 'logs' do
+        allow(context).to receive(:notice)
+        expect(context).to receive(:notice).with('noop: false').once
 
-      provider.create(context, 'a', name: 'a', ensure: 'present')
+        provider.set(context, {}, noop: false)
+      end
     end
-  end
+    context 'with noop: true' do
+      it 'logs' do
+        allow(context).to receive(:notice)
+        expect(context).to receive(:notice).with('noop: true').once
 
-  describe 'update(context, name, should)' do
-    it 'updates the resource' do
-      expect(context).to receive(:notice).with(%r{\AUpdating 'foo'})
-
-      provider.update(context, 'foo', name: 'foo', ensure: 'present')
-    end
-  end
-
-  describe 'delete(context, name, should)' do
-    it 'deletes the resource' do
-      expect(context).to receive(:notice).with(%r{\ADeleting 'foo'})
-
-      provider.delete(context, 'foo')
+        provider.set(context, {}, noop: true)
+      end
     end
   end
 end

--- a/spec/integration/resource_api_spec.rb
+++ b/spec/integration/resource_api_spec.rb
@@ -187,6 +187,12 @@ RSpec.describe 'Resource API integrated tests:' do
     end
 
     context 'with a instance of the type' do
+      # the catalog here is required to mock out the catalog used in
+      # https://github.com/puppetlabs/puppet/blob/fb96f5115b0a7033ee6624173a7c3be8e0d1f572/lib/puppet/type.rb#L1416-L1433
+      # to have a quick check of the working of metaparams here, without having to stand up
+      # a complete catalog.
+      # See spec/acceptance/metaparam_spec.rb for more in-depth testing with a full puppet apply
+      let(:catalog) { instance_double('Puppet::Resource::Catalog', 'catalog') }
       let(:instance) do
         type.new(name: 'somename', ensure: 'present', boolean: true, integer: 15, float: 1.23,
                  variant_pattern: '0x1234ABCD', url: 'http://www.google.com', string_array: %w[a b c],
@@ -194,7 +200,14 @@ RSpec.describe 'Resource API integrated tests:' do
                  array_from_hell: ['a', %w[subb subc], 'd'],
                  boolean_param: false, integer_param: 99, float_param: 3.21, ensure_param: 'present',
                  variant_pattern_param: '1234ABCD', url_param:  'http://www.puppet.com',
-                 string_array_param: %w[d e f])
+                 string_array_param: %w[d e f], alias: 'bar', audit: 'all', loglevel: 'crit', noop: false,
+                 tag: %w[a b c], catalog: catalog)
+      end
+
+      before(:each) do
+        allow(catalog).to receive(:resource).and_return nil
+        allow(catalog).to receive(:alias).and_return nil
+        allow(catalog).to receive(:host_config?).and_return true
       end
 
       it('flushes') { expect { instance.flush }.not_to raise_exception }


### PR DESCRIPTION
Example error message:

```
Notice: /Stage[main]/Main/Node[cat-2960]/Tacacs_server[192.168.198.41]/ensure: defined 'ensure' as 'present'
Error: /Stage[main]/Main/Node[cat-2960]/Tacacs_server[192.168.198.41]: Could not evaluate: undefined method `rs_value' for #<Puppet::Type::MetaParamRequire:0x000000000276e8a8>
Did you mean? value
/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0/gems/puppet-resource_api-1.4.0/lib/puppet/resource_api.rb:346:in `block (3 levels) in register_type'
/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0/gems/puppet-resource_api-1.4.0/lib/puppet/resource_api.rb:346:in `each'
/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0/gems/puppet-resource_api-1.4.0/lib/puppet/resource_api.rb:346:in `map'
/opt/puppetlabs/puppet/lib/ruby/gems/2.4.0/gems/puppet-resource_api-1.4.0/lib/puppet/resource_api.rb:346:in `block (2 levels) in register_type'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/transaction/resource_harness.rb:25:in `evaluate'
```