### PR TITLE
(MODULES-7679) Fix up simple_get_filter feature

### DIFF
--- a/spec/acceptance/simple_get_filter_spec.rb
+++ b/spec/acceptance/simple_get_filter_spec.rb
@@ -7,30 +7,29 @@ RSpec.describe 'exercising simple_get_filter' do
   let(:common_args) { '--verbose --debug --trace --strict=error --modulepath spec/fixtures' }
 
   describe 'using `puppet resource`' do
-    context 'when using `get` to access all resources' do
+    context 'when using `get` to access the initial data set' do
       it 'does not receive names array' do
         stdout_str, status = Open3.capture2e("puppet resource #{common_args} test_simple_get_filter")
 
+        expect(stdout_str.strip).to match %r{^test_simple_get_filter \{ 'wibble'}
         expect(stdout_str.strip).to match %r{^test_simple_get_filter \{ 'bar'}
-        expect(stdout_str.strip).to match %r{^test_simple_get_filter \{ 'foo'}
         expect(status).to eq 0
       end
     end
 
     context 'when using `get` to access a specific resource' do
       it '`puppet resource` uses `instances` and does the filtering' do
-        stdout_str, status = Open3.capture2e("puppet resource #{common_args} test_simple_get_filter foo")
+        stdout_str, status = Open3.capture2e("puppet resource #{common_args} test_simple_get_filter wibble")
 
-        expect(stdout_str.strip).to match %r{test_string\s*=>\s*'default'}
+        expect(stdout_str.strip).to match %r{test_string\s*=>\s*'wibble default'}
         expect(status).to eq 0
       end
     end
 
     context 'when using `get` to remove a specific resource' do
       it 'the `retrieve` function does the lookup' do
-        stdout_str, status = Open3.capture2e("puppet resource #{common_args} --noop test_simple_get_filter foo ensure=absent")
+        stdout_str, status = Open3.capture2e("puppet resource #{common_args} test_simple_get_filter foo")
 
-        expect(stdout_str.strip).to match %r{current_value '?present'?, should be '?absent'? \(noop\)}
         expect(stdout_str.strip).to match %r{test_string\s*=>\s*'foo found'}
         expect(status).to eq 0
       end

--- a/spec/fixtures/test_module/lib/puppet/provider/test_simple_get_filter/test_simple_get_filter.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/test_simple_get_filter/test_simple_get_filter.rb
@@ -4,36 +4,27 @@ require 'puppet/resource_api/simple_provider'
 # Implementation for the test_simple_get_filter type using the Resource API.
 class Puppet::Provider::TestSimpleGetFilter::TestSimpleGetFilter < Puppet::ResourceApi::SimpleProvider
   def get(_context, names = nil)
-    if names.nil?
-      [
-        {
-          name: 'bar',
-          ensure: 'present',
-          test_string: 'default',
-        },
-        {
-          name: 'foo',
-          ensure: 'present',
-          test_string: 'default',
-        },
-      ]
-    elsif names.include?('foo')
-      [
-        {
-          name: 'foo',
-          ensure: 'present',
-          test_string: 'foo found',
-        },
-      ]
-    else
-      [
-        {
-          name: names.first,
-          ensure: 'present',
-          test_string: 'not foo',
-        },
-      ]
-    end
+    raise Puppet::DevError, 'names parameter must be provided to TestSimpleGetFilter#get()' if names.nil?
+
+    result = if names.empty?
+               # rather than fething everything from your large dataset, return a subset of the data that you are happy to show.
+               # This will be cached by Puppet. If a resource requested exists in the cache, then no futher calls are made to the provider.
+               [{
+                 name: 'wibble',
+                 ensure: 'present',
+                 test_string: 'wibble default',
+               },
+                {
+                  name: 'bar',
+                  ensure: 'present',
+                  test_string: 'bar default',
+                }]
+             else
+               # If the resource(s) requested does not exist in the cache the provider will be called with its name(s)
+               # and a subsequent query to your large dataset can be made with that information
+               names.map { |name| { name: name, ensure: 'present', test_string: "#{name} found" } }
+             end
+    result
   end
 
   def create(_context, _name, _should); end

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -1644,6 +1644,11 @@ CODE
       expect { described_class.register_type(definition) }.not_to raise_error
     end
 
+    it 'passes through the an empty array to `get`' do
+      expect(provider).to receive(:get).with(anything, []).and_return([])
+      type.instances
+    end
+
     it 'passes through the resource title to `get`' do
       instance = type.new(name: 'bar', ensure: 'present')
       expect(provider).to receive(:get).with(anything, ['bar']).and_return([])


### PR DESCRIPTION
Corrected to allow the provider to decide on the subset to return when no specific resource is provided.

Will now correctly fetch the required resource from the cache or make a new call via the provider if it is not found in the cache.