### PR TITLE
(PDK-1150) Allow providers to override :title when retrieving resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,6 @@ Restrictions of puppet:
 * Attributes cannot be called `title`, `provider`, or any of the [metaparameters](https://puppet.com/docs/puppet/5.5/metaparameter.html), as those are reserved by puppet itself.
 
 Future possibilities:
-* [Composite Namevars](https://tickets.puppetlabs.com/browse/PDK-531)
 * [Multiple Providers](https://tickets.puppetlabs.com/browse/PDK-530)
 * [Commands API](https://tickets.puppetlabs.com/browse/PDK-847)
 

--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -309,7 +309,12 @@ module Puppet::ResourceApi
 
         initial_fetch.map do |resource_hash|
           type_definition.check_schema(resource_hash)
-          result = new(title: resource_hash[type_definition.namevars.first])
+          # allow a :title from the provider to override the default
+          result = if resource_hash.key? :title
+                     new(title: resource_hash[:title])
+                   else
+                     new(title: resource_hash[type_definition.namevars.first])
+                   end
           result.cache_current_state(resource_hash)
           result
         end

--- a/lib/puppet/resource_api/type_definition.rb
+++ b/lib/puppet/resource_api/type_definition.rb
@@ -74,7 +74,7 @@ class Puppet::ResourceApi::TypeDefinition
   # Modifies the resource passed in, leaving only valid attributes
   def check_schema_keys(resource)
     rejected = []
-    resource.reject! { |key| rejected << key unless attributes.key? key }
+    resource.reject! { |key| rejected << key if key != :title && attributes.key?(key) == false }
     rejected
   end
 

--- a/spec/fixtures/test_module/lib/puppet/provider/composite_namevar/composite_namevar.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/composite_namevar/composite_namevar.rb
@@ -4,12 +4,12 @@ require 'puppet/resource_api'
 class Puppet::Provider::CompositeNamevar::CompositeNamevar
   def initialize
     @current_values ||= [
-      { package: 'php', manager: 'yum', ensure: 'present', value: 'a' },
-      { package: 'php', manager: 'gem', ensure: 'present', value: 'b' },
-      { package: 'mysql', manager: 'yum', ensure: 'present', value: 'c' },
-      { package: 'mysql', manager: 'gem', ensure: 'present', value: 'd' },
-      { package: 'foo', manager: 'bar', ensure: 'present', value: 'e' },
-      { package: 'bar', manager: 'foo', ensure: 'present', value: 'f' },
+      { title: 'php-yum', package: 'php', manager: 'yum', ensure: 'present', value: 'a' },
+      { title: 'php-gem', package: 'php', manager: 'gem', ensure: 'present', value: 'b' },
+      { title: 'mysql-yum', package: 'mysql', manager: 'yum', ensure: 'present', value: 'c' },
+      { title: 'mysql-gem', package: 'mysql', manager: 'gem', ensure: 'present', value: 'd' },
+      { title: 'foo-bar', package: 'foo', manager: 'bar', ensure: 'present', value: 'e' },
+      { title: 'bar-foo', package: 'bar', manager: 'foo', ensure: 'present', value: 'f' },
     ]
   end
 

--- a/spec/fixtures/test_module/lib/puppet/type/composite_namevar.rb
+++ b/spec/fixtures/test_module/lib/puppet/type/composite_namevar.rb
@@ -11,8 +11,8 @@ Puppet::ResourceApi.register_type(
       desc: 'Where the package and the manager are provided with a hyphen seperator',
     },
     {
-      pattern: %r{^(?<package>.*)$},
-      desc: 'Where only the package is provided',
+      pattern: %r{^(?<package>.*[^/])/(?<manager>.*)$},
+      desc: 'Where the package and the manager are provided with a forward slash seperator',
     },
   ],
   attributes:   {
@@ -34,6 +34,6 @@ Puppet::ResourceApi.register_type(
     value:     {
       type: 'Optional[String]',
       desc: 'An arbitrary string for debugging purposes',
-    }
+    },
   },
 )

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -976,7 +976,7 @@ RSpec.describe Puppet::ResourceApi do
     end
   end
 
-  context 'when registering a type with title_patterns' do
+  context 'when registering a type with title_patterns', agent_test: true do
     let(:definition) do
       {
         name: 'composite',
@@ -1019,12 +1019,13 @@ RSpec.describe Puppet::ResourceApi do
       let(:provider_class) do
         Class.new do
           def get(_context)
-            [{ package: 'php', manager: 'yum', ensure: 'present' }]
+            [{ title: 'php/yum', package: 'php', manager: 'yum', ensure: 'present' }]
           end
 
           def set(_context, _changes); end
         end
       end
+      let(:instance) { Puppet::Type.type(:composite) }
 
       before(:each) do
         stub_const('Puppet::Provider::Composite', Module.new)
@@ -1032,8 +1033,6 @@ RSpec.describe Puppet::ResourceApi do
       end
 
       context 'when title_patterns called' do
-        let(:instance) { Puppet::Type.type(:composite) }
-
         it 'returns correctly generated pattern' do
           # [[ %r{^(?<package>.*[^/])/(?<manager>.*)$},[[:package],[:manager]]],[%r{^(?<package>.*)$},[[:package]]]]
 
@@ -1047,6 +1046,12 @@ RSpec.describe Puppet::ResourceApi do
           expect(instance.title_patterns.last[0]).to eq(%r{^(?<package>.*)$})
           expect(instance.title_patterns.last[1].size).to eq 1
           expect(instance.title_patterns.last[1][0][0]).to eq :package
+        end
+      end
+
+      context 'when instances called' do
+        it 'uses the title provided by the provider' do
+          expect(instance.instances[0].title).to eq('php/yum')
         end
       end
     end


### PR DESCRIPTION
This change facilitates composite namevar functionality.