### PR TITLE
(maint) create a new default value instance on every access

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -188,9 +188,13 @@ module Puppet::ResourceApi
                 # work around https://tickets.puppetlabs.com/browse/PUP-2368
                 defaultto :true # rubocop:disable Lint/BooleanSymbol
               else
-                defaultto options[:default]
+                # marshal the default option to decouple that from the actual value.
+                # we cache the dumped value in `marshalled`, but use a block to unmarshal
+                # everytime the value is requested. Objects that can't be marshalled
+                # See https://stackoverflow.com/a/8206537/4918
+                marshalled = Marshal.dump(options[:default])
+                defaultto { Marshal.load(marshalled) } # rubocop:disable Security/MarshalLoad
               end
-              # defaultto options[:default]
             end
           end
 


### PR DESCRIPTION
Using the value straight from the type definition leads to aliasing
problems, where anyone accessing this value and mutating it (e.g.
adding an element to an array), would modify the actual default value.

Using Marshal dump/load in a block creates a new instance everytime
the default value is evaluated, and will address this issue completely.