### PR TITLE
Minor spelling fix

### DIFF
--- a/spec/fixtures/test_module/lib/puppet/type/composite_namevar.rb
+++ b/spec/fixtures/test_module/lib/puppet/type/composite_namevar.rb
@@ -8,11 +8,11 @@ Puppet::ResourceApi.register_type(
   title_patterns: [
     {
       pattern: %r{^(?<package>.*[^-])-(?<manager>.*)$},
-      desc: 'Where the package and the manager are provided with a hyphen seperator',
+      desc: 'Where the package and the manager are provided with a hyphen separator',
     },
     {
       pattern: %r{^(?<package>.*[^/])/(?<manager>.*)$},
-      desc: 'Where the package and the manager are provided with a forward slash seperator',
+      desc: 'Where the package and the manager are provided with a forward slash separator',
     },
   ],
   attributes:   {

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -1083,7 +1083,7 @@ RSpec.describe Puppet::ResourceApi do
         title_patterns: [
           {
             pattern: %r{^(?<package>.*[^/])/(?<manager>.*)$},
-            desc: 'Where the package and the manager are provided with a slash seperator',
+            desc: 'Where the package and the manager are provided with a slash separator',
           },
           {
             pattern: %r{^(?<package>.*)$},


### PR DESCRIPTION
seperator changed to separator

It should be also changed in other places such in here here https://github.com/puppetlabs/puppet-specifications/blob/master/language/resource-api/README.md