### PR TITLE
(PDK-1209) setting inherited const_defined lookup to false

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -46,7 +46,7 @@ module Puppet::ResourceApi
     # this has to happen before Puppet::Type.newtype starts autoloading providers
     # it also needs to be guarded against the namespace already being defined by something
     # else to avoid ruby warnings
-    unless Puppet::Provider.const_defined?(class_name_from_type_name(definition[:name]))
+    unless Puppet::Provider.const_defined?(class_name_from_type_name(definition[:name]), false)
       Puppet::Provider.const_set(class_name_from_type_name(definition[:name]), Module.new)
     end
 


### PR DESCRIPTION

If there is a top level module with same name as a type which gets loaded before the type gets defined then this will trigger a false positive on the `last_module.const_defined?` check causing an `uninitialized constant` error.

This change will no longer do a recursive check and only care about the local namespace this way avoiding the false positive. 
