### PR TITLE
(PDK-1209) Fix the other call-sites of const_defined? and const_get

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -543,16 +543,16 @@ MESSAGE
   def load_default_provider(class_name, type_name_sym)
     # loads the "puppet/provider/#{type_name}/#{type_name}" file through puppet
     Puppet::Type.type(type_name_sym).provider(type_name_sym)
-    Puppet::Provider.const_get(class_name).const_get(class_name)
+    Puppet::Provider.const_get(class_name, false).const_get(class_name, false)
   end
   module_function :load_default_provider # rubocop:disable Style/AccessModifierDeclarations
 
   def load_device_provider(class_name, type_name_sym, device_class_name, device_name_sym)
     # loads the "puppet/provider/#{type_name}/#{device_name}" file through puppet
     Puppet::Type.type(type_name_sym).provider(device_name_sym)
-    provider_module = Puppet::Provider.const_get(class_name)
-    if provider_module.const_defined?(device_class_name)
-      provider_module.const_get(device_class_name)
+    provider_module = Puppet::Provider.const_get(class_name, false)
+    if provider_module.const_defined?(device_class_name, false)
+      provider_module.const_get(device_class_name, false)
     else
       load_default_provider(class_name, type_name_sym)
     end

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Puppet::ResourceApi do
     end
 
     describe Puppet::Provider do
-      it('has a module prepared for the provider') { expect(described_class.const_get('Minimal').name).to eq 'Puppet::Provider::Minimal' }
+      it('has a module prepared for the provider') { expect(described_class.const_get('Minimal', false).name).to eq 'Puppet::Provider::Minimal' }
     end
   end
 


### PR DESCRIPTION
Same as #132, there are more const_get and const_defined? calls that
need to ignore inherited names.