### PR TITLE
(maint) Predeclare Puppet module before ResourceApi

### DIFF
--- a/lib/puppet/resource_api/data_type_handling.rb
+++ b/lib/puppet/resource_api/data_type_handling.rb
@@ -1,4 +1,4 @@
-module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation
+module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation,Style/ClassAndModuleChildren
 
 # This module is used to handle data inside types, contains methods for munging
 # and validation of the type values.

--- a/lib/puppet/resource_api/data_type_handling.rb
+++ b/lib/puppet/resource_api/data_type_handling.rb
@@ -1,4 +1,4 @@
-module Puppet::ResourceApi; end # predeclare the main module # rubocop:disable Style/Documentation
+module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation
 
 # This module is used to handle data inside types, contains methods for munging
 # and validation of the type values.


### PR DESCRIPTION
Fixes failures to load the resource API in puppet-agent before the
puppet module has been declared.

https://github.com/puppetlabs/puppet-resource_api/pull/138 broke ruby smoke tests in puppet-agent acceptance last night; This change seems to fix the problem (but I'll close this if you'd rather address it some other way)