### PR TITLE
Move parameter and property logic to separate classes

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -201,6 +201,12 @@ module Puppet::ResourceApi
             raise Puppet::DevError, "#{definition[:name]}.#{name} has no type"
           end
 
+          if options[:desc]
+            desc "#{options[:desc]} (a #{options[:type]})"
+          else
+            warn("#{definition[:name]}.#{name} has no docs")
+          end
+
           # The initialize takes passed hash with resource.
           # The method pass needed arguments, depending on parent to:
           # - Puppet::ResourceApi::Property
@@ -212,36 +218,31 @@ module Puppet::ResourceApi
             super(name, data_type, data_definition, resource_hash[:resource])
           end
 
-          if options[:desc]
-            desc "#{options[:desc]} (a #{options[:type]})"
-          else
-            warn("#{definition[:name]}.#{name} has no docs")
-          end
-
+          # get type class object for the parameter or property
           type = Puppet::ResourceApi::DataTypeHandling.parse_puppet_type(
             name,
             options[:type],
           )
-
-          # inside of parameter or property provide method to check and return
-          # data type.
-          define_method(:data_type) do
-            type
-          end
-
-          # inside of parameter or property provide method to check and return
-          # the definition hash object.
-          define_method(:data_definition) do
-            definition
-          end
 
           # provide hints to `puppet type generate` for better parsing
           if type.instance_of? Puppet::Pops::Types::POptionalType
             type = type.type
           end
 
-          # Initialize ValueCreator and call create_values which creates alias
-          # values and default values for properties and params.
+          # inside of parameter or property provide method to check and return
+          # data type
+          define_method(:data_type) do
+            type
+          end
+
+          # inside of parameter or property provide method to check and return
+          # the definition hash object
+          define_method(:data_definition) do
+            definition
+          end
+
+          # initialize ValueCreator and call create_values which makes alias
+          # values and default values for properties and params
           Puppet::ResourceApi::ValueCreator.new(
             self,
             type,

--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -10,8 +10,6 @@ require 'puppet/resource_api/value_creator'
 require 'puppet/resource_api/version'
 require 'puppet/type'
 require 'puppet/util/network_device'
-require 'puppet/property'
-require 'puppet/parameter'
 
 module Puppet::ResourceApi
   @warning_count = 0

--- a/lib/puppet/resource_api/parameter.rb
+++ b/lib/puppet/resource_api/parameter.rb
@@ -1,0 +1,42 @@
+require 'puppet/parameter'
+
+module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation,Style/ClassAndModuleChildren
+
+# Class containing parameter functionality for ResourceApi.
+class Puppet::ResourceApi::Parameter < Puppet::Parameter
+  # This initialize takes arguments and sets up new parameter.
+  # @param name the name used for reporting errors
+  # @param type the type instance
+  # @param definition the definition of the property
+  # @param resource the resource instance which is passed to the parent class.
+  def initialize(name, type, definiton, resource)
+    @name = name
+    @type = type
+    @definiton = definiton
+    super(resource: resource) # Pass resource to parent Puppet class.
+  end
+
+  # This method handles return of assigned value from parameter.
+  # @return [type] the type value
+  def value
+    @value
+  end
+
+  # This method assigns value to the parameter and cleans value.
+  # @param value the value to be set and clean
+  # @return [type] the cleaned value
+  def value=(value)
+    @value = Puppet::ResourceApi::DataTypeHandling.mungify(
+      @type,
+      value,
+      "#{@definiton[:name]}.#{name}",
+      Puppet::ResourceApi.caller_is_resource_app?,
+    )
+  end
+
+  # used internally
+  # @returns the final mungified value of this parameter
+  def rs_value
+    @value
+  end
+end

--- a/lib/puppet/resource_api/parameter.rb
+++ b/lib/puppet/resource_api/parameter.rb
@@ -39,4 +39,10 @@ class Puppet::ResourceApi::Parameter < Puppet::Parameter
   def rs_value
     @value
   end
+
+  # puppet symbolizes some values through puppet/parameter/value.rb
+  # (see .convert()), but (especially) Enums are strings. specifying a
+  # munge block here skips the value_collection fallback in
+  # puppet/parameter.rb's default .unsafe_munge() implementation.
+  munge { |v| v }
 end

--- a/lib/puppet/resource_api/parameter.rb
+++ b/lib/puppet/resource_api/parameter.rb
@@ -1,25 +1,23 @@
+require 'puppet/util'
 require 'puppet/parameter'
 
 module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation,Style/ClassAndModuleChildren
 
 # Class containing parameter functionality for ResourceApi.
 class Puppet::ResourceApi::Parameter < Puppet::Parameter
-  # This initialize takes arguments and sets up new parameter.
-  # @param name the name used for reporting errors
-  # @param type the type instance
-  # @param definition the definition of the property
-  # @param resource the resource instance which is passed to the parent class.
-  def initialize(name, type, definiton, resource)
-    @name = name
-    @type = type
-    @definiton = definiton
-    super(resource: resource) # Pass resource to parent Puppet class.
-  end
+  attr_reader :value
 
-  # This method handles return of assigned value from parameter.
-  # @return [type] the type value
-  def value
-    @value
+  # This initialize takes arguments and sets up new parameter.
+  # @param type_name the name of the Puppet Type
+  # @param data_type the data type of parameter instance
+  # @param attribute_name the name of attribue of the parameter
+  # @param resource_hash the resource hash instance which is passed to the
+  # parent class.
+  def initialize(type_name, data_type, attribute_name, resource_hash)
+    @type_name = type_name
+    @data_type = data_type
+    @attribute_name = attribute_name
+    super(resource_hash) # Pass resource to parent Puppet class.
   end
 
   # This method assigns value to the parameter and cleans value.
@@ -27,9 +25,9 @@ class Puppet::ResourceApi::Parameter < Puppet::Parameter
   # @return [type] the cleaned value
   def value=(value)
     @value = Puppet::ResourceApi::DataTypeHandling.mungify(
-      @type,
+      @data_type,
       value,
-      "#{@definiton[:name]}.#{name}",
+      "#{@type_name}.#{@attribute_name}",
       Puppet::ResourceApi.caller_is_resource_app?,
     )
   end

--- a/lib/puppet/resource_api/property.rb
+++ b/lib/puppet/resource_api/property.rb
@@ -1,0 +1,64 @@
+require 'puppet/property'
+
+module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation,Style/ClassAndModuleChildren
+
+# Class containing property functionality for ResourceApi.
+class Puppet::ResourceApi::Property < Puppet::Property
+  # This initialize takes arguments and sets up new property.
+  # @param name the name used for reporting errors
+  # @param type the type instance
+  # @param definition the definition of the property
+  # @param resource the resource instance which is passed to the parent class.
+  def initialize(name, type, definition, resource)
+    @name = name
+    @type = type
+    @definition = definition
+    # Pass resource and should to parent Puppet class.
+    super(resource: resource, should: should)
+  end
+
+  # This method returns value of the property.
+  # @return [type] the property value
+  def should
+    if @name == :ensure && rs_value.is_a?(String)
+      rs_value.to_sym
+    elsif rs_value == false
+      # work around https://tickets.puppetlabs.com/browse/PUP-2368
+      :false # rubocop:disable Lint/BooleanSymbol
+    elsif rs_value == true
+      # work around https://tickets.puppetlabs.com/browse/PUP-2368
+      :true # rubocop:disable Lint/BooleanSymbol
+    else
+      rs_value
+    end
+  end
+
+  # This method sets and returns value of the property and sets @shouldorig.
+  # @param value the value to be set and clean
+  # @return [type] the property value
+  def should=(value)
+    @shouldorig = value
+
+    if @name == :ensure
+      value = value.to_s
+    end
+
+    # Puppet requires the @should value to always be stored as an array. We do not use this
+    # for anything else
+    # @see Puppet::Property.should=(value)
+    @should = [
+      Puppet::ResourceApi::DataTypeHandling.mungify(
+        @type,
+        value,
+        "#{@definition[:name]}.#{@name}",
+        Puppet::ResourceApi.caller_is_resource_app?,
+      ),
+    ]
+  end
+
+  # used internally
+  # @returns the final mungified value of this property
+  def rs_value
+    @should ? @should.first : @should
+  end
+end

--- a/lib/puppet/resource_api/property.rb
+++ b/lib/puppet/resource_api/property.rb
@@ -77,4 +77,9 @@ class Puppet::ResourceApi::Property < Puppet::Property
   # munge block here skips the value_collection fallback in
   # puppet/parameter.rb's default .unsafe_munge() implementation.
   munge { |v| v }
+
+  # stop puppet from trying to call into the provider when
+  # no pre-defined values have been specified
+  # "This is not the provider you are looking for." -- Obi-Wan Kaniesobi.
+  def call_provider(_value); end
 end

--- a/lib/puppet/resource_api/property.rb
+++ b/lib/puppet/resource_api/property.rb
@@ -16,7 +16,7 @@ class Puppet::ResourceApi::Property < Puppet::Property
     @data_type = data_type
     @attribute_name = attribute_name
     # Define class method insync?(is) if the name is :ensure
-    def_insync? if @attribute_name == :ensure
+    def_insync? if @attribute_name == :ensure && self.class != Puppet::ResourceApi::Property
     # Pass resource to parent Puppet class.
     super(resource_hash)
   end
@@ -70,7 +70,7 @@ class Puppet::ResourceApi::Property < Puppet::Property
   # rs_value matches is. Only if the class is child of
   # Puppet::ResourceApi::Property.
   def def_insync?
-    self.class.send(:define_method, :insync?) { |is| rs_value.to_s == is.to_s } unless self.class == Puppet::ResourceApi::Property
+    define_singleton_method(:insync?) { |is| rs_value.to_s == is.to_s }
   end
 
   # puppet symbolizes some values through puppet/parameter/value.rb

--- a/lib/puppet/resource_api/property.rb
+++ b/lib/puppet/resource_api/property.rb
@@ -66,10 +66,11 @@ class Puppet::ResourceApi::Property < Puppet::Property
     @should ? @should.first : @should
   end
 
-  # method added only for the :ensure property, add option to check if the
-  # rs_value matches is
+  # method overloaded only for the :ensure property, add option to check if the
+  # rs_value matches is. Only if the class is child of
+  # Puppet::ResourceApi::Property.
   def def_insync?
-    self.class.send(:define_method, :insync?) { |is| rs_value.to_s == is.to_s }
+    self.class.send(:define_method, :insync?) { |is| rs_value.to_s == is.to_s } unless self.class == Puppet::ResourceApi::Property
   end
 
   # puppet symbolizes some values through puppet/parameter/value.rb

--- a/lib/puppet/resource_api/property.rb
+++ b/lib/puppet/resource_api/property.rb
@@ -13,6 +13,8 @@ class Puppet::ResourceApi::Property < Puppet::Property
     @name = name
     @type = type
     @definition = definition
+    # Define class method insync?(is) if the name is :ensure
+    def_insync? if @name == :ensure
     # Pass resource and should to parent Puppet class.
     super(resource: resource, should: should)
   end
@@ -61,4 +63,16 @@ class Puppet::ResourceApi::Property < Puppet::Property
   def rs_value
     @should ? @should.first : @should
   end
+
+  # method added only for the :ensure property, add option to check if the
+  # rs_value matches is
+  def def_insync?
+    self.class.send(:define_method, :insync?) { |is| rs_value.to_s == is.to_s }
+  end
+
+  # puppet symbolizes some values through puppet/parameter/value.rb
+  # (see .convert()), but (especially) Enums are strings. specifying a
+  # munge block here skips the value_collection fallback in
+  # puppet/parameter.rb's default .unsafe_munge() implementation.
+  munge { |v| v }
 end

--- a/lib/puppet/resource_api/property.rb
+++ b/lib/puppet/resource_api/property.rb
@@ -1,3 +1,4 @@
+require 'puppet/util'
 require 'puppet/property'
 
 module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation,Style/ClassAndModuleChildren
@@ -5,24 +6,25 @@ module Puppet; module ResourceApi; end; end # predeclare the main module # ruboc
 # Class containing property functionality for ResourceApi.
 class Puppet::ResourceApi::Property < Puppet::Property
   # This initialize takes arguments and sets up new property.
-  # @param name the name used for reporting errors
-  # @param type the type instance
-  # @param definition the definition of the property
-  # @param resource the resource instance which is passed to the parent class.
-  def initialize(name, type, definition, resource)
-    @name = name
-    @type = type
-    @definition = definition
+  # @param type_name the name of the Puppet Type
+  # @param data_type the data type of property instance
+  # @param attribute_name the name of attribue of the property
+  # @param resource_hash the resource hash instance which is passed to the
+  # parent class.
+  def initialize(type_name, data_type, attribute_name, resource_hash)
+    @type_name = type_name
+    @data_type = data_type
+    @attribute_name = attribute_name
     # Define class method insync?(is) if the name is :ensure
-    def_insync? if @name == :ensure
-    # Pass resource and should to parent Puppet class.
-    super(resource: resource, should: should)
+    def_insync? if @attribute_name == :ensure
+    # Pass resource to parent Puppet class.
+    super(resource_hash)
   end
 
   # This method returns value of the property.
   # @return [type] the property value
   def should
-    if @name == :ensure && rs_value.is_a?(String)
+    if @attribute_name == :ensure && rs_value.is_a?(String)
       rs_value.to_sym
     elsif rs_value == false
       # work around https://tickets.puppetlabs.com/browse/PUP-2368
@@ -41,7 +43,7 @@ class Puppet::ResourceApi::Property < Puppet::Property
   def should=(value)
     @shouldorig = value
 
-    if @name == :ensure
+    if @attribute_name == :ensure
       value = value.to_s
     end
 
@@ -50,9 +52,9 @@ class Puppet::ResourceApi::Property < Puppet::Property
     # @see Puppet::Property.should=(value)
     @should = [
       Puppet::ResourceApi::DataTypeHandling.mungify(
-        @type,
+        @data_type,
         value,
-        "#{@definition[:name]}.#{@name}",
+        "#{@type_name}.#{@attribute_name}",
         Puppet::ResourceApi.caller_is_resource_app?,
       ),
     ]

--- a/lib/puppet/resource_api/read_only_parameter.rb
+++ b/lib/puppet/resource_api/read_only_parameter.rb
@@ -34,4 +34,10 @@ class Puppet::ResourceApi::ReadOnlyParameter < Puppet::Property
   def rs_value
     @value
   end
+
+  # puppet symbolizes some values through puppet/parameter/value.rb
+  # (see .convert()), but (especially) Enums are strings. specifying a
+  # munge block here skips the value_collection fallback in
+  # puppet/parameter.rb's default .unsafe_munge() implementation.
+  munge { |v| v }
 end

--- a/lib/puppet/resource_api/read_only_parameter.rb
+++ b/lib/puppet/resource_api/read_only_parameter.rb
@@ -1,0 +1,37 @@
+require 'puppet/parameter'
+
+module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation,Style/ClassAndModuleChildren
+
+# Class containing read only parameter functionality for ResourceApi.
+class Puppet::ResourceApi::ReadOnlyParameter < Puppet::Property
+  # This initialize takes arguments and sets up new parameter.
+  # @param name the name used for reporting errors
+  # @param type the type instance
+  # @param definition the definition of the property
+  # @param resource the resource instance which is passed to the parent class.
+  def initialize(name, type, definition, resource)
+    @name = name
+    @type = type
+    @definition = definition
+    super(resource: resource) # Pass resource to parent Puppet class.
+  end
+
+  # This method handles return of assigned value from parameter.
+  # @return [type] the type value
+  def value # rubocop:disable Style/TrivialAccessors
+    @value
+  end
+
+  # This method raises error if the there is attempt to set value in parameter.
+  # @return [Puppet::ResourceError] the error with information.
+  def value=(value)
+    raise Puppet::ResourceError,
+          "Attempting to set `#{@name}` read_only attribute value to `#{value}`"
+  end
+
+  # used internally
+  # @returns the final mungified value of this parameter
+  def rs_value
+    @value
+  end
+end

--- a/lib/puppet/resource_api/read_only_parameter.rb
+++ b/lib/puppet/resource_api/read_only_parameter.rb
@@ -1,32 +1,14 @@
-require 'puppet/parameter'
-
-module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation,Style/ClassAndModuleChildren
+require 'puppet/util'
+require 'puppet/resource_api/parameter'
 
 # Class containing read only parameter functionality for ResourceApi.
-class Puppet::ResourceApi::ReadOnlyParameter < Puppet::Property
-  # This initialize takes arguments and sets up new parameter.
-  # @param name the name used for reporting errors
-  # @param type the type instance
-  # @param definition the definition of the property
-  # @param resource the resource instance which is passed to the parent class.
-  def initialize(name, type, definition, resource)
-    @name = name
-    @type = type
-    @definition = definition
-    super(resource: resource) # Pass resource to parent Puppet class.
-  end
-
-  # This method handles return of assigned value from parameter.
-  # @return [type] the type value
-  def value # rubocop:disable Style/TrivialAccessors
-    @value
-  end
-
+class Puppet::ResourceApi::ReadOnlyParameter < Puppet::ResourceApi::Parameter
   # This method raises error if the there is attempt to set value in parameter.
   # @return [Puppet::ResourceError] the error with information.
   def value=(value)
     raise Puppet::ResourceError,
-          "Attempting to set `#{@name}` read_only attribute value to `#{value}`"
+          "Attempting to set `#{@attribute_name}` read_only attribute value " \
+          "to `#{value}`"
   end
 
   # used internally
@@ -34,10 +16,4 @@ class Puppet::ResourceApi::ReadOnlyParameter < Puppet::Property
   def rs_value
     @value
   end
-
-  # puppet symbolizes some values through puppet/parameter/value.rb
-  # (see .convert()), but (especially) Enums are strings. specifying a
-  # munge block here skips the value_collection fallback in
-  # puppet/parameter.rb's default .unsafe_munge() implementation.
-  munge { |v| v }
 end

--- a/lib/puppet/resource_api/value_creator.rb
+++ b/lib/puppet/resource_api/value_creator.rb
@@ -54,8 +54,6 @@ module Puppet::ResourceApi::ValueCreator
       def_newvalues(resource_class, param_or_property, Puppet::Pops::Patterns::NUMERIC)
     end
 
-    def_call_provider(resource_class) if param_or_property == :newproperty
-
     case options[:type]
     when 'Enum[present, absent]'
       def_newvalues(resource_class, param_or_property, 'absent', 'present')
@@ -73,12 +71,5 @@ module Puppet::ResourceApi::ValueCreator
         this.newvalue(v) {}
       end
     end
-  end
-
-  # stop puppet from trying to call into the provider when
-  # no pre-defined values have been specified
-  # "This is not the provider you are looking for." -- Obi-Wan Kaniesobi.
-  def self.def_call_provider(resource_class)
-    resource_class.send(:define_method, :call_provider) { |value| }
   end
 end

--- a/lib/puppet/resource_api/value_creator.rb
+++ b/lib/puppet/resource_api/value_creator.rb
@@ -3,6 +3,14 @@ module Puppet; module ResourceApi; end; end # predeclare the main module # ruboc
 # This class is responsible for setting default and alias values for the
 # resource class.
 class Puppet::ResourceApi::ValueCreator
+  # This initialize takes arguments and sets up new value creator for given
+  # resource class which can be Puppet::ResourceApi::Parameter,
+  # Puppet::ResourceApi::ReadOnlyParameter, Puppet::ResourceApi::Property.
+  # @param resource_class the class of selected resource to be extended
+  # @param data_type the type instance
+  # @param definition the definition of the property
+  # @param options the ResourceAPI options hash containing setup information for
+  # selected parameter or property
   def initialize(resource_class, data_type, param_or_property, options = {})
     @resource_class = resource_class
     @data_type = data_type
@@ -58,8 +66,8 @@ class Puppet::ResourceApi::ValueCreator
     end
   end
 
-  # Add the value to `this` property or param, depending on whether
-  # param_or_property is `:newparam`, or `:newproperty`.
+  # add the value to `this` property or param, depending on whether
+  # param_or_property is `:newparam`, or `:newproperty`
   def def_newvalues(this, *values)
     if @param_or_property == :newparam
       this.newvalues(*values)

--- a/lib/puppet/resource_api/value_creator.rb
+++ b/lib/puppet/resource_api/value_creator.rb
@@ -17,22 +17,20 @@ class Puppet::ResourceApi::ValueCreator
 
     # read-only values do not need type checking, but can have default values
     if @options[:behaviour] != :read_only && @options.key?(:default)
-      if @options.key? :default
-        if @options[:default] == false
-          # work around https://tickets.puppetlabs.com/browse/PUP-2368
-          @resource_class.defaultto :false # rubocop:disable Lint/BooleanSymbol
-        elsif @options[:default] == true
-          # work around https://tickets.puppetlabs.com/browse/PUP-2368
-          @resource_class.defaultto :true # rubocop:disable Lint/BooleanSymbol
-        else
-          # marshal the default option to decouple that from the actual value.
-          # we cache the dumped value in `marshalled`, but use a block to
-          # unmarshal everytime the value is requested. Objects that can't be
-          # marshalled
-          # See https://stackoverflow.com/a/8206537/4918
-          marshalled = Marshal.dump(@options[:default])
-          @resource_class.defaultto { Marshal.load(marshalled) } # rubocop:disable Security/MarshalLoad
-        end
+      if @options[:default] == false
+        # work around https://tickets.puppetlabs.com/browse/PUP-2368
+        @resource_class.defaultto :false # rubocop:disable Lint/BooleanSymbol
+      elsif @options[:default] == true
+        # work around https://tickets.puppetlabs.com/browse/PUP-2368
+        @resource_class.defaultto :true # rubocop:disable Lint/BooleanSymbol
+      else
+        # marshal the default option to decouple that from the actual value.
+        # we cache the dumped value in `marshalled`, but use a block to
+        # unmarshal everytime the value is requested. Objects that can't be
+        # marshalled
+        # See https://stackoverflow.com/a/8206537/4918
+        marshalled = Marshal.dump(@options[:default])
+        @resource_class.defaultto { Marshal.load(marshalled) } # rubocop:disable Security/MarshalLoad
       end
     end
 

--- a/lib/puppet/resource_api/value_creator.rb
+++ b/lib/puppet/resource_api/value_creator.rb
@@ -1,0 +1,81 @@
+module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation,Style/ClassAndModuleChildren
+
+# This class is responsible for setting default and alias values for the
+# resource class.
+class Puppet::ResourceApi::ValueCreator
+  def initialize(resource_class, data_type, param_or_property, options = {})
+    @resource_class = resource_class
+    @data_type = data_type
+    @param_or_property = param_or_property
+    @options = options
+  end
+
+  # This method is responsible for all setup of the value mapping for desired
+  # resource class.
+  def create_values
+    @resource_class.isnamevar if @options[:behaviour] == :namevar
+
+    # read-only values do not need type checking, but can have default values
+    if @options[:behaviour] != :read_only && @options.key?(:default)
+      if @options.key? :default
+        if @options[:default] == false
+          # work around https://tickets.puppetlabs.com/browse/PUP-2368
+          @resource_class.defaultto :false # rubocop:disable Lint/BooleanSymbol
+        elsif @options[:default] == true
+          # work around https://tickets.puppetlabs.com/browse/PUP-2368
+          @resource_class.defaultto :true # rubocop:disable Lint/BooleanSymbol
+        else
+          # marshal the default option to decouple that from the actual value.
+          # we cache the dumped value in `marshalled`, but use a block to
+          # unmarshal everytime the value is requested. Objects that can't be
+          # marshalled
+          # See https://stackoverflow.com/a/8206537/4918
+          marshalled = Marshal.dump(@options[:default])
+          @resource_class.defaultto { Marshal.load(marshalled) } # rubocop:disable Security/MarshalLoad
+        end
+      end
+    end
+
+    case @data_type
+    when Puppet::Pops::Types::PStringType
+      # require any string value
+      def_newvalues(@resource_class, %r{})
+    when Puppet::Pops::Types::PBooleanType
+      def_newvalues(@resource_class, 'true', 'false')
+      @resource_class.aliasvalue true, 'true'
+      @resource_class.aliasvalue false, 'false'
+      @resource_class.aliasvalue :true, 'true' # rubocop:disable Lint/BooleanSymbol
+      @resource_class.aliasvalue :false, 'false' # rubocop:disable Lint/BooleanSymbol
+    when Puppet::Pops::Types::PIntegerType
+      def_newvalues(@resource_class, %r{^-?\d+$})
+    when Puppet::Pops::Types::PFloatType, Puppet::Pops::Types::PNumericType
+      def_newvalues(@resource_class, Puppet::Pops::Patterns::NUMERIC)
+    end
+
+    def_call_provider() if @param_or_property == :newproperty
+
+    case @options[:type]
+    when 'Enum[present, absent]'
+      def_newvalues(@resource_class, 'absent', 'present')
+    end
+  end
+
+  # Add the value to `this` property or param, depending on whether
+  # param_or_property is `:newparam`, or `:newproperty`.
+  def def_newvalues(this, *values)
+    if @param_or_property == :newparam
+      this.newvalues(*values)
+    else
+      values.each do |v|
+        this.newvalue(v) {}
+      end
+    end
+  end
+
+  # stop puppet from trying to call into the provider when
+  # no pre-defined values have been specified
+  # "This is not the provider you are looking for." -- Obi-Wan Kaniesobi.
+  def def_call_provider
+    @resource_class.send(:define_method, :call_provider) { |value| }
+  end
+end

--- a/lib/puppet/resource_api/value_creator.rb
+++ b/lib/puppet/resource_api/value_creator.rb
@@ -11,17 +11,17 @@ module Puppet::ResourceApi::ValueCreator
   # @param definition the definition of the property
   # @param options the ResourceAPI options hash containing setup information for
   # selected parameter or property
-  def self.create_values(resource_class, data_type, param_or_property, options = {})
-    resource_class.isnamevar if options[:behaviour] == :namevar
+  def self.create_values(attribute_class, data_type, param_or_property, options = {})
+    attribute_class.isnamevar if options[:behaviour] == :namevar
 
     # read-only values do not need type checking, but can have default values
     if options[:behaviour] != :read_only && options.key?(:default)
       if options[:default] == false
         # work around https://tickets.puppetlabs.com/browse/PUP-2368
-        resource_class.defaultto :false # rubocop:disable Lint/BooleanSymbol
+        attribute_class.defaultto :false # rubocop:disable Lint/BooleanSymbol
       elsif options[:default] == true
         # work around https://tickets.puppetlabs.com/browse/PUP-2368
-        resource_class.defaultto :true # rubocop:disable Lint/BooleanSymbol
+        attribute_class.defaultto :true # rubocop:disable Lint/BooleanSymbol
       else
         # marshal the default option to decouple that from the actual value.
         # we cache the dumped value in `marshalled`, but use a block to
@@ -29,7 +29,7 @@ module Puppet::ResourceApi::ValueCreator
         # marshalled
         # See https://stackoverflow.com/a/8206537/4918
         marshalled = Marshal.dump(options[:default])
-        resource_class.defaultto { Marshal.load(marshalled) } # rubocop:disable Security/MarshalLoad
+        attribute_class.defaultto { Marshal.load(marshalled) } # rubocop:disable Security/MarshalLoad
       end
     end
 
@@ -41,24 +41,24 @@ module Puppet::ResourceApi::ValueCreator
     case data_type
     when Puppet::Pops::Types::PStringType
       # require any string value
-      def_newvalues(resource_class, param_or_property, %r{})
+      def_newvalues(attribute_class, param_or_property, %r{})
     when Puppet::Pops::Types::PBooleanType
-      def_newvalues(resource_class, param_or_property, 'true', 'false')
-      resource_class.aliasvalue true, 'true'
-      resource_class.aliasvalue false, 'false'
-      resource_class.aliasvalue :true, 'true' # rubocop:disable Lint/BooleanSymbol
-      resource_class.aliasvalue :false, 'false' # rubocop:disable Lint/BooleanSymbol
+      def_newvalues(attribute_class, param_or_property, 'true', 'false')
+      attribute_class.aliasvalue true, 'true'
+      attribute_class.aliasvalue false, 'false'
+      attribute_class.aliasvalue :true, 'true' # rubocop:disable Lint/BooleanSymbol
+      attribute_class.aliasvalue :false, 'false' # rubocop:disable Lint/BooleanSymbol
     when Puppet::Pops::Types::PIntegerType
-      def_newvalues(resource_class, param_or_property, %r{^-?\d+$})
+      def_newvalues(attribute_class, param_or_property, %r{^-?\d+$})
     when Puppet::Pops::Types::PFloatType, Puppet::Pops::Types::PNumericType
-      def_newvalues(resource_class, param_or_property, Puppet::Pops::Patterns::NUMERIC)
+      def_newvalues(attribute_class, param_or_property, Puppet::Pops::Patterns::NUMERIC)
     end
 
     case options[:type]
     when 'Enum[present, absent]'
-      def_newvalues(resource_class, param_or_property, 'absent', 'present')
+      def_newvalues(attribute_class, param_or_property, 'absent', 'present')
     end
-    resource_class
+    attribute_class
   end
 
   # add the value to `this` property or param, depending on whether

--- a/lib/puppet/resource_api/value_creator.rb
+++ b/lib/puppet/resource_api/value_creator.rb
@@ -1,9 +1,9 @@
 module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation,Style/ClassAndModuleChildren
 
-# This class is responsible for setting default and alias values for the
+# This module is responsible for setting default and alias values for the
 # resource class.
-class Puppet::ResourceApi::ValueCreator
-  # This initialize takes arguments and sets up new value creator for given
+module Puppet::ResourceApi::ValueCreator
+  # This method is responsible for all setup of the value mapping for desired
   # resource class which can be Puppet::ResourceApi::Parameter,
   # Puppet::ResourceApi::ReadOnlyParameter, Puppet::ResourceApi::Property.
   # @param resource_class the class of selected resource to be extended
@@ -11,65 +11,62 @@ class Puppet::ResourceApi::ValueCreator
   # @param definition the definition of the property
   # @param options the ResourceAPI options hash containing setup information for
   # selected parameter or property
-  def initialize(resource_class, data_type, param_or_property, options = {})
-    @resource_class = resource_class
-    @data_type = data_type
-    @param_or_property = param_or_property
-    @options = options
-  end
-
-  # This method is responsible for all setup of the value mapping for desired
-  # resource class.
-  def create_values
-    @resource_class.isnamevar if @options[:behaviour] == :namevar
+  def self.create_values(resource_class, data_type, param_or_property, options = {})
+    resource_class.isnamevar if options[:behaviour] == :namevar
 
     # read-only values do not need type checking, but can have default values
-    if @options[:behaviour] != :read_only && @options.key?(:default)
-      if @options[:default] == false
+    if options[:behaviour] != :read_only && options.key?(:default)
+      if options[:default] == false
         # work around https://tickets.puppetlabs.com/browse/PUP-2368
-        @resource_class.defaultto :false # rubocop:disable Lint/BooleanSymbol
-      elsif @options[:default] == true
+        resource_class.defaultto :false # rubocop:disable Lint/BooleanSymbol
+      elsif options[:default] == true
         # work around https://tickets.puppetlabs.com/browse/PUP-2368
-        @resource_class.defaultto :true # rubocop:disable Lint/BooleanSymbol
+        resource_class.defaultto :true # rubocop:disable Lint/BooleanSymbol
       else
         # marshal the default option to decouple that from the actual value.
         # we cache the dumped value in `marshalled`, but use a block to
         # unmarshal everytime the value is requested. Objects that can't be
         # marshalled
         # See https://stackoverflow.com/a/8206537/4918
-        marshalled = Marshal.dump(@options[:default])
-        @resource_class.defaultto { Marshal.load(marshalled) } # rubocop:disable Security/MarshalLoad
+        marshalled = Marshal.dump(options[:default])
+        resource_class.defaultto { Marshal.load(marshalled) } # rubocop:disable Security/MarshalLoad
       end
     end
 
-    case @data_type
+    # provide hints to `puppet type generate` for better parsing
+    if data_type.instance_of? Puppet::Pops::Types::POptionalType
+      data_type = data_type.type
+    end
+
+    case data_type
     when Puppet::Pops::Types::PStringType
       # require any string value
-      def_newvalues(@resource_class, %r{})
+      def_newvalues(resource_class, param_or_property, %r{})
     when Puppet::Pops::Types::PBooleanType
-      def_newvalues(@resource_class, 'true', 'false')
-      @resource_class.aliasvalue true, 'true'
-      @resource_class.aliasvalue false, 'false'
-      @resource_class.aliasvalue :true, 'true' # rubocop:disable Lint/BooleanSymbol
-      @resource_class.aliasvalue :false, 'false' # rubocop:disable Lint/BooleanSymbol
+      def_newvalues(resource_class, param_or_property, 'true', 'false')
+      resource_class.aliasvalue true, 'true'
+      resource_class.aliasvalue false, 'false'
+      resource_class.aliasvalue :true, 'true' # rubocop:disable Lint/BooleanSymbol
+      resource_class.aliasvalue :false, 'false' # rubocop:disable Lint/BooleanSymbol
     when Puppet::Pops::Types::PIntegerType
-      def_newvalues(@resource_class, %r{^-?\d+$})
+      def_newvalues(resource_class, param_or_property, %r{^-?\d+$})
     when Puppet::Pops::Types::PFloatType, Puppet::Pops::Types::PNumericType
-      def_newvalues(@resource_class, Puppet::Pops::Patterns::NUMERIC)
+      def_newvalues(resource_class, param_or_property, Puppet::Pops::Patterns::NUMERIC)
     end
 
-    def_call_provider() if @param_or_property == :newproperty
+    def_call_provider(resource_class) if param_or_property == :newproperty
 
-    case @options[:type]
+    case options[:type]
     when 'Enum[present, absent]'
-      def_newvalues(@resource_class, 'absent', 'present')
+      def_newvalues(resource_class, param_or_property, 'absent', 'present')
     end
+    resource_class
   end
 
   # add the value to `this` property or param, depending on whether
   # param_or_property is `:newparam`, or `:newproperty`
-  def def_newvalues(this, *values)
-    if @param_or_property == :newparam
+  def self.def_newvalues(this, param_or_property, *values)
+    if param_or_property == :newparam
       this.newvalues(*values)
     else
       values.each do |v|
@@ -81,7 +78,7 @@ class Puppet::ResourceApi::ValueCreator
   # stop puppet from trying to call into the provider when
   # no pre-defined values have been specified
   # "This is not the provider you are looking for." -- Obi-Wan Kaniesobi.
-  def def_call_provider
-    @resource_class.send(:define_method, :call_provider) { |value| }
+  def self.def_call_provider(resource_class)
+    resource_class.send(:define_method, :call_provider) { |value| }
   end
 end

--- a/spec/puppet/resource_api/parameter_spec.rb
+++ b/spec/puppet/resource_api/parameter_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+RSpec.describe Puppet::ResourceApi::Parameter do
+  subject(:parameter) do
+    described_class.new(name, type, definition, resource)
+  end
+
+  let(:definition) { {} }
+  let(:log_sink) { [] }
+  let(:name) { 'some_parameter' }
+  let(:resource) { {} }
+  let(:result) { 'value' }
+  let(:strict_level) { :error }
+  let(:type) { Puppet::Pops::Types::PStringType.new(nil) }
+  let(:value) { 'value' }
+
+  before(:each) do
+    # set default to strictest setting
+    # by default Puppet runs at warning level
+    Puppet.settings[:strict] = strict_level
+    # Enable debug logging
+    Puppet.debug = true
+
+    Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(log_sink))
+  end
+
+  after(:each) do
+    Puppet::Util::Log.close_all
+  end
+
+  it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
+  it { expect { described_class.new(name, type, definition, resource) }.not_to raise_error }
+
+  describe '#value=(value)' do
+    context 'when value is string' do
+      context 'when the value is set with string value' do
+        it('value is returned') do
+          expect(parameter.value=(value)).to eq result
+        end
+
+        it('value=(value) is called') do
+          allow(described_class).to receive(:value=).with(value).and_return(result)
+          described_class.value=(value) # rubocop:disable Style/RedundantParentheses, Layout/SpaceAroundOperators
+          expect(described_class).to have_received(:value=).once
+        end
+      end
+    end
+  end
+
+  describe '#value' do
+    context 'when the value is not set' do
+      it('nil is returned') do
+        expect(parameter.value).to eq nil
+      end
+    end
+
+    context 'when value is string' do
+      context 'when the value is set' do
+        it('value is called') do
+          allow(described_class).to receive(:value).and_return(result)
+          described_class.value
+          expect(described_class).to have_received(:value).once
+        end
+
+        it('value is returned') do
+          parameter.instance_variable_set(:@value, value)
+          expect(parameter.value).to eq result
+        end
+      end
+    end
+  end
+
+  describe '#rs_value' do
+    context 'when the value is not set' do
+      it('nil is returned') do
+        expect(parameter.value).to eq nil
+      end
+    end
+
+    context 'when value is string' do
+      context 'when the value is set' do
+        it('value is called') do
+          allow(described_class).to receive(:rs_value).and_return(result)
+          described_class.rs_value
+          expect(described_class).to have_received(:rs_value).once
+        end
+
+        it('value is returned') do
+          parameter.instance_variable_set(:@value, value)
+          expect(parameter.rs_value).to eq result
+        end
+      end
+    end
+  end
+end

--- a/spec/puppet/resource_api/parameter_spec.rb
+++ b/spec/puppet/resource_api/parameter_spec.rb
@@ -2,40 +2,24 @@ require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::Parameter do
   subject(:parameter) do
-    described_class.new(name, type, definition, resource)
+    described_class.new(type_name, data_type, attribute_name, resource_hash)
   end
 
-  let(:definition) { {} }
-  let(:log_sink) { [] }
-  let(:name) { 'some_parameter' }
-  let(:resource) { {} }
+  let(:type_name) { 'test_name' }
+  let(:attribute_name) { 'some_parameter' }
+  let(:data_type) { Puppet::Pops::Types::PStringType.new(nil) }
+  let(:resource_hash) { { resource: {} } }
   let(:result) { 'value' }
-  let(:strict_level) { :error }
-  let(:type) { Puppet::Pops::Types::PStringType.new(nil) }
   let(:value) { 'value' }
 
-  before(:each) do
-    # set default to strictest setting
-    # by default Puppet runs at warning level
-    Puppet.settings[:strict] = strict_level
-    # Enable debug logging
-    Puppet.debug = true
-
-    Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(log_sink))
-  end
-
-  after(:each) do
-    Puppet::Util::Log.close_all
-  end
-
   it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
-  it { expect { described_class.new(name, type, definition, resource) }.not_to raise_error }
+  it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash) }.not_to raise_error }
 
   describe '#value=(value)' do
     context 'when value is string' do
       context 'when the value is set with string value' do
         it('value is returned') do
-          expect(parameter.value=(value)).to eq result
+          expect(parameter.value=(value)).to eq result # rubocop:disable Style/RedundantParentheses, Layout/SpaceAroundOperators
         end
 
         it('value=(value) is called') do

--- a/spec/puppet/resource_api/parameter_spec.rb
+++ b/spec/puppet/resource_api/parameter_spec.rb
@@ -9,70 +9,59 @@ RSpec.describe Puppet::ResourceApi::Parameter do
   let(:attribute_name) { 'some_parameter' }
   let(:data_type) { Puppet::Pops::Types::PStringType.new(nil) }
   let(:resource_hash) { { resource: {} } }
-  let(:result) { 'value' }
-  let(:value) { 'value' }
 
-  it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
-  it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash) }.not_to raise_error }
+  describe '#new(type_name, data_type, attribute_name, resource_hash)' do
+    it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
+    it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash) }.not_to raise_error }
+  end
 
   describe '#value=(value)' do
-    context 'when value is string' do
-      context 'when the value is set with string value' do
-        it('value is returned') do
-          expect(parameter.value=(value)).to eq result # rubocop:disable Style/RedundantParentheses, Layout/SpaceAroundOperators
-        end
+    it 'calls mungify and stores the munged value' do
+      expect(Puppet::ResourceApi::DataTypeHandling).to receive(:mungify)
+        .with(data_type, 'value', 'test_name.some_parameter', false)
+        .and_return('munged value')
 
-        it('value=(value) is called') do
-          allow(described_class).to receive(:value=).with(value).and_return(result)
-          described_class.value=(value) # rubocop:disable Style/RedundantParentheses, Layout/SpaceAroundOperators
-          expect(described_class).to have_received(:value=).once
-        end
-      end
+      parameter.value = 'value'
+
+      expect(parameter.value).to eq 'munged value'
+    end
+
+    it 'calls mungify and reports its error' do
+      expect(Puppet::ResourceApi::DataTypeHandling).to receive(:mungify)
+        .and_raise Exception, 'error'
+
+      expect { parameter.value = 'value' }.to raise_error Exception, 'error'
+
+      expect(parameter.value).to eq nil
     end
   end
 
   describe '#value' do
     context 'when the value is not set' do
-      it('nil is returned') do
+      it 'nil is returned' do
         expect(parameter.value).to eq nil
       end
     end
 
-    context 'when value is string' do
-      context 'when the value is set' do
-        it('value is called') do
-          allow(described_class).to receive(:value).and_return(result)
-          described_class.value
-          expect(described_class).to have_received(:value).once
-        end
-
-        it('value is returned') do
-          parameter.instance_variable_set(:@value, value)
-          expect(parameter.value).to eq result
-        end
+    context 'when the value is set' do
+      it 'value is returned' do
+        parameter.instance_variable_set(:@value, 'value')
+        expect(parameter.value).to eq 'value'
       end
     end
   end
 
   describe '#rs_value' do
     context 'when the value is not set' do
-      it('nil is returned') do
-        expect(parameter.value).to eq nil
+      it 'nil is returned' do
+        expect(parameter.rs_value).to eq nil
       end
     end
 
-    context 'when value is string' do
-      context 'when the value is set' do
-        it('value is called') do
-          allow(described_class).to receive(:rs_value).and_return(result)
-          described_class.rs_value
-          expect(described_class).to have_received(:rs_value).once
-        end
-
-        it('value is returned') do
-          parameter.instance_variable_set(:@value, value)
-          expect(parameter.rs_value).to eq result
-        end
+    context 'when the value is set' do
+      it 'value is returned' do
+        parameter.instance_variable_set(:@value, 'value')
+        expect(parameter.rs_value).to eq 'value'
       end
     end
   end

--- a/spec/puppet/resource_api/property_spec.rb
+++ b/spec/puppet/resource_api/property_spec.rb
@@ -13,54 +13,9 @@ RSpec.describe Puppet::ResourceApi::Property do
   describe '#new(type_name, data_type, attribute_name, resource_hash)' do
     it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
     it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash) }.not_to raise_error }
-
-    context 'when name is :ensure' do
-      let(:attribute_name) { :ensure }
-
-      it 'the #insync? method is avaliable' do
-        expect(property.methods.include?(:insync?)).to eq true
-      end
-    end
   end
 
-  describe '#should=(value)' do
-    context 'when value is string type' do
-      it 'calls mungify and stores the munged value' do
-        expect(Puppet::ResourceApi::DataTypeHandling).to receive(:mungify)
-          .with(data_type, 'value', 'test_name.some_property', false)
-          .and_return('munged value')
-
-        property.should = 'value'
-
-        expect(property.value).to eq 'munged value'
-      end
-    end
-
-    context 'when attribute name is :ensure' do
-      let(:attribute_name) { :ensure }
-      let(:data_type) { Puppet::Pops::Types::PEnumType.new(%w[absent present]) }
-
-      it 'calls mungify and stores the munged symbol value' do
-        expect(Puppet::ResourceApi::DataTypeHandling).to receive(:mungify)
-          .with(data_type, 'absent', 'test_name.ensure', false)
-          .and_return('absent')
-
-        property.should = :absent
-
-        expect(property.should).to eq :absent
-      end
-    end
-
-    it 'calls mungify and stores the munged value' do
-      expect(Puppet::ResourceApi::DataTypeHandling).to receive(:mungify)
-        .with(data_type, 'value', 'test_name.some_property', false)
-        .and_return('munged value')
-
-      property.should = 'value'
-
-      expect(property.value).to eq 'munged value'
-    end
-
+  describe 'should error handling' do
     it 'calls mungify and reports its error' do
       expect(Puppet::ResourceApi::DataTypeHandling).to receive(:mungify)
         .and_raise Exception, 'error'
@@ -71,56 +26,32 @@ RSpec.describe Puppet::ResourceApi::Property do
     end
   end
 
-  describe '#should' do
-    context 'when the should is not set' do
-      it 'nil is returned' do
-        expect(property.should).to eq nil
-      end
+  describe 'value munging and storage' do
+    before(:each) do
+      allow(Puppet::ResourceApi::DataTypeHandling).to receive(:mungify)
+        .with(data_type, value, 'test_name.some_property', false)
+        .and_return(munged_value)
+
+      property.should = value
     end
 
-    context 'when the should is set' do
-      context 'when should is string' do
-        it 'value is returned' do
-          property.instance_variable_set(:@should, ['value'])
-          expect(property.should).to eq 'value'
-        end
-      end
+    context 'when handling strings' do
+      let(:value) { 'value' }
+      let(:munged_value) { 'munged value' }
 
-      context 'when should is boolean' do
-        it ':false symbol value is returned' do
-          property.instance_variable_set(:@should, [false])
-          expect(property.should).to eq :false # rubocop:disable Lint/BooleanSymbol
-        end
-
-        it ':true symbol value is returned' do
-          property.instance_variable_set(:@should, [true])
-          expect(property.should).to eq :true # rubocop:disable Lint/BooleanSymbol
-        end
-      end
-
-      context 'when atribute name is :ensure' do
-        let(:attribute_name) { :ensure }
-
-        it 'symbol value is returned' do
-          property.instance_variable_set(:@should, ['present'])
-          expect(property.should).to eq :present
-        end
-      end
-    end
-  end
-
-  describe '#rs_value' do
-    context 'when the value is not set' do
-      it 'nil is returned' do
-        expect(property.rs_value).to eq nil
-      end
+      it { expect(property.should).to eq 'munged value' }
+      it { expect(property.rs_value).to eq 'munged value' }
+      it { expect(property.value).to eq 'munged value' }
     end
 
-    context 'when the value is set' do
-      it 'value is returned' do
-        property.instance_variable_set(:@should, ['value'])
-        expect(property.rs_value).to eq 'value'
-      end
+    context 'when handling boolean true' do
+      let(:value) { true }
+      let(:munged_value) { true }
+      let(:data_type) { Puppet::Pops::Types::PBooleanType.new }
+
+      it { expect(property.should).to eq :true } # rubocop:disable Lint/BooleanSymbol
+      it { expect(property.rs_value).to eq true }
+      it { expect(property.value).to eq :true } # rubocop:disable Lint/BooleanSymbol
     end
   end
 end

--- a/spec/puppet/resource_api/property_spec.rb
+++ b/spec/puppet/resource_api/property_spec.rb
@@ -2,33 +2,17 @@ require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::Property do
   subject(:property) do
-    described_class.new(name, type, definition, resource)
+    described_class.new(type_name, data_type, attribute_name, resource_hash)
   end
 
-  let(:definition) { {} }
-  let(:log_sink) { [] }
-  let(:name) { 'some_property' }
-  let(:resource) { {} }
+  let(:type_name) { 'test_name' }
+  let(:attribute_name) { 'some_property' }
+  let(:data_type) { Puppet::Pops::Types::PStringType.new(nil) }
+  let(:resource_hash) { { resource: {} } }
   let(:result) { 'value' }
-  let(:strict_level) { :error }
-  let(:type) { Puppet::Pops::Types::PStringType.new(nil) }
-
-  before(:each) do
-    # set default to strictest setting
-    # by default Puppet runs at warning level
-    Puppet.settings[:strict] = strict_level
-    # Enable debug logging
-    Puppet.debug = true
-
-    Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(log_sink))
-  end
-
-  after(:each) do
-    Puppet::Util::Log.close_all
-  end
 
   it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
-  it { expect { described_class.new(name, type, definition, resource) }.not_to raise_error }
+  it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash) }.not_to raise_error }
 
   describe '#should=(value)' do
     context 'when value is string' do
@@ -43,7 +27,7 @@ RSpec.describe Puppet::ResourceApi::Property do
         end
 
         it('value is returned') do
-          expect(property.should=(value)).to eq result
+          expect(property.should=(value)).to eq result # rubocop:disable Style/RedundantParentheses, Layout/SpaceAroundOperators
         end
       end
     end
@@ -53,9 +37,9 @@ RSpec.describe Puppet::ResourceApi::Property do
     context 'when value is boolean' do
       context 'when the @should is set' do
         let(:should_true_value) { [true] } # rs_value takes value in array
-        let(:true_result) { :true }
+        let(:true_result) { :true } # rubocop:disable Lint/BooleanSymbol
         let(:should_false_value) { [false] } # rs_value takes value in array
-        let(:false_result) { :false }
+        let(:false_result) { :false } # rubocop:disable Lint/BooleanSymbol
 
         it('true symbol value is returned') do
           property.instance_variable_set(:@should, should_true_value)
@@ -74,7 +58,7 @@ RSpec.describe Puppet::ResourceApi::Property do
         context 'when the @should is set' do
           let(:should_value) { ['present'] } # rs_value takes value in array
           let(:name) { :ensure }
-          let(:result) { :present }
+          let(:result) { 'present' }
 
           it('symbol value is returned') do
             property.instance_variable_set(:@should, should_value)

--- a/spec/puppet/resource_api/property_spec.rb
+++ b/spec/puppet/resource_api/property_spec.rb
@@ -28,24 +28,28 @@ RSpec.describe Puppet::ResourceApi::Property do
     end
     let(:ensure_property) { ensure_property_class.new }
 
+    before(:each) do
+      allow(Puppet::ResourceApi::DataTypeHandling).to receive(:mungify)
+        .with(Puppet::Pops::Types::PEnumType.new(%w[absent present]), 'present', 'test_name.ensure', false)
+        .and_return('present')
+
+      ensure_property.should = 'present'
+    end
+
     it 'has a #insync? method' do
       expect(ensure_property.public_methods(false)).to include(:insync?)
     end
 
     describe '#insync?' do
-      let(:data_type) { Puppet::Pops::Types::PEnumType.new(%w[absent present]) }
-
-      before(:each) do
-        allow(Puppet::ResourceApi::DataTypeHandling).to receive(:mungify)
-          .with(data_type, 'present', 'test_name.ensure', false)
-          .and_return('present')
-
-        ensure_property.should = 'present'
-      end
-
       it 'compares using symbols' do
         expect(ensure_property.insync?(:present)).to eq(true)
       end
+    end
+
+    context "when handling 'present' string" do
+      it { expect(ensure_property.should).to eq :present }
+      it { expect(ensure_property.rs_value).to eq 'present' }
+      it { expect(ensure_property.value).to eq :present }
     end
   end
 

--- a/spec/puppet/resource_api/property_spec.rb
+++ b/spec/puppet/resource_api/property_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+
+RSpec.describe Puppet::ResourceApi::Property do
+  subject(:property) do
+    described_class.new(name, type, definition, resource)
+  end
+
+  let(:definition) { {} }
+  let(:log_sink) { [] }
+  let(:name) { 'some_property' }
+  let(:resource) { {} }
+  let(:result) { 'value' }
+  let(:strict_level) { :error }
+  let(:type) { Puppet::Pops::Types::PStringType.new(nil) }
+
+  before(:each) do
+    # set default to strictest setting
+    # by default Puppet runs at warning level
+    Puppet.settings[:strict] = strict_level
+    # Enable debug logging
+    Puppet.debug = true
+
+    Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(log_sink))
+  end
+
+  after(:each) do
+    Puppet::Util::Log.close_all
+  end
+
+  it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
+  it { expect { described_class.new(name, type, definition, resource) }.not_to raise_error }
+
+  describe '#should=(value)' do
+    context 'when value is string' do
+      context 'when the should is set with string value' do
+        let(:value) { 'value' }
+
+        it('value is called') do
+          allow(described_class).to receive(:should=).with(value).and_return(result)
+          allow(described_class).to receive(:rs_value).and_return(result)
+          described_class.should=(value) # rubocop:disable Style/RedundantParentheses, Layout/SpaceAroundOperators
+          expect(described_class).to have_received(:should=).once
+        end
+
+        it('value is returned') do
+          expect(property.should=(value)).to eq result
+        end
+      end
+    end
+  end
+
+  describe '#should' do
+    context 'when value is boolean' do
+      context 'when the @should is set' do
+        let(:should_true_value) { [true] } # rs_value takes value in array
+        let(:true_result) { :true }
+        let(:should_false_value) { [false] } # rs_value takes value in array
+        let(:false_result) { :false }
+
+        it('true symbol value is returned') do
+          property.instance_variable_set(:@should, should_true_value)
+          expect(property.should).to eq true_result
+        end
+
+        it('false symbol value is returned') do
+          property.instance_variable_set(:@should, should_false_value)
+          expect(property.should).to eq false_result
+        end
+      end
+    end
+
+    context 'when value is string' do
+      context 'when the name is :ensure' do
+        context 'when the @should is set' do
+          let(:should_value) { ['present'] } # rs_value takes value in array
+          let(:name) { :ensure }
+          let(:result) { :present }
+
+          it('symbol value is returned') do
+            property.instance_variable_set(:@should, should_value)
+            property.instance_variable_set(:@name, name)
+            expect(property.should).to eq result
+          end
+        end
+      end
+
+      context 'when the should is set' do
+        let(:should_value) { ['value'] } # rs_value takes value in array
+
+        it('value is called') do
+          allow(described_class).to receive(:should).and_return(result)
+          described_class.should
+          expect(described_class).to have_received(:should).once
+        end
+
+        it('value is returned') do
+          property.instance_variable_set(:@should, should_value)
+          expect(property.should).to eq result
+        end
+      end
+    end
+  end
+
+  describe '#rs_value' do
+    context 'when the value is not set' do
+      it('nil is returned') do
+        expect(property.value).to eq nil
+      end
+    end
+
+    context 'when value is string' do
+      let(:should_value) { ['value'] }
+
+      context 'when the value is set' do
+        it('value is called') do
+          allow(described_class).to receive(:rs_value).and_return(result)
+          described_class.rs_value
+          expect(described_class).to have_received(:rs_value).once
+        end
+
+        it('value is returned') do
+          property.instance_variable_set(:@should, should_value)
+          expect(property.rs_value).to eq result
+        end
+      end
+    end
+  end
+end

--- a/spec/puppet/resource_api/read_only_parameter_spec.rb
+++ b/spec/puppet/resource_api/read_only_parameter_spec.rb
@@ -2,40 +2,27 @@ require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::ReadOnlyParameter do
   subject(:read_only_parameter) do
-    described_class.new(name, type, definition, resource)
+    described_class.new(type_name, data_type, attribute_name, resource_hash)
   end
 
-  let(:definition) { {} }
-  let(:log_sink) { [] }
-  let(:name) { 'some_parameter' }
-  let(:resource) { {} }
+  let(:type_name) { 'test_name' }
+  let(:attribute_name) { 'some_parameter' }
+  let(:data_type) { Puppet::Pops::Types::PStringType }
+  let(:resource_hash) { { resource: {} } }
   let(:result) { 'value' }
-  let(:strict_level) { :error }
-  let(:type) { Puppet::Pops::Types::PStringType }
   let(:value) { 'value' }
 
-  before(:each) do
-    # set default to strictest setting
-    # by default Puppet runs at warning level
-    Puppet.settings[:strict] = strict_level
-    # Enable debug logging
-    Puppet.debug = true
-
-    Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(log_sink))
-  end
-
-  after(:each) do
-    Puppet::Util::Log.close_all
-  end
-
   it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
-  it { expect { described_class.new(name, type, definition, resource) }.not_to raise_error }
+  it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash) }.not_to raise_error }
 
   describe '#value=(value)' do
     context 'when called from `puppet resource`' do
       context 'when the value set attempt is performed' do
         it 'value set fails' do
-          expect { read_only_parameter.value=(value) }.to raise_error Puppet::ResourceError, %r{Attempting to set `some_parameter` read_only attribute value to `value`} # rubocop:disable Style/RedundantParentheses, Layout/SpaceAroundOperators
+          expect { read_only_parameter.value=(value) }.to raise_error( # rubocop:disable Style/RedundantParentheses, Layout/SpaceAroundOperators
+            Puppet::ResourceError,
+            %r{Attempting to set `some_parameter` read_only attribute value to `value`},
+          )
         end
       end
     end

--- a/spec/puppet/resource_api/read_only_parameter_spec.rb
+++ b/spec/puppet/resource_api/read_only_parameter_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+RSpec.describe Puppet::ResourceApi::ReadOnlyParameter do
+  subject(:read_only_parameter) do
+    described_class.new(name, type, definition, resource)
+  end
+
+  let(:definition) { {} }
+  let(:log_sink) { [] }
+  let(:name) { 'some_parameter' }
+  let(:resource) { {} }
+  let(:result) { 'value' }
+  let(:strict_level) { :error }
+  let(:type) { Puppet::Pops::Types::PStringType }
+  let(:value) { 'value' }
+
+  before(:each) do
+    # set default to strictest setting
+    # by default Puppet runs at warning level
+    Puppet.settings[:strict] = strict_level
+    # Enable debug logging
+    Puppet.debug = true
+
+    Puppet::Util::Log.newdestination(Puppet::Test::LogCollector.new(log_sink))
+  end
+
+  after(:each) do
+    Puppet::Util::Log.close_all
+  end
+
+  it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
+  it { expect { described_class.new(name, type, definition, resource) }.not_to raise_error }
+
+  describe '#value=(value)' do
+    context 'when called from `puppet resource`' do
+      context 'when the value set attempt is performed' do
+        it 'value set fails' do
+          expect { read_only_parameter.value=(value) }.to raise_error Puppet::ResourceError, %r{Attempting to set `some_parameter` read_only attribute value to `value`} # rubocop:disable Style/RedundantParentheses, Layout/SpaceAroundOperators
+        end
+      end
+    end
+  end
+
+  describe '#value' do
+    context 'when value is string' do
+      context 'when the value is set' do
+        before(:each) do
+          allow(described_class).to receive(:value).and_return(result)
+        end
+
+        it('value is called') do
+          described_class.value
+          expect(described_class).to have_received(:value).once
+        end
+
+        it('value is returned') do
+          expect(described_class.value).to eq result
+        end
+      end
+    end
+  end
+
+  describe '#rs_value' do
+    context 'when the value is not set' do
+      it('nil is returned') do
+        expect(read_only_parameter.value).to eq nil
+      end
+    end
+
+    context 'when value is string' do
+      context 'when the value is set' do
+        it('value is called') do
+          allow(described_class).to receive(:rs_value).and_return(result)
+          described_class.rs_value
+          expect(described_class).to have_received(:rs_value).once
+        end
+
+        it('value is returned') do
+          read_only_parameter.instance_variable_set(:@value, value)
+          expect(read_only_parameter.rs_value).to eq result
+        end
+      end
+    end
+  end
+end

--- a/spec/puppet/resource_api/read_only_parameter_spec.rb
+++ b/spec/puppet/resource_api/read_only_parameter_spec.rb
@@ -7,19 +7,19 @@ RSpec.describe Puppet::ResourceApi::ReadOnlyParameter do
 
   let(:type_name) { 'test_name' }
   let(:attribute_name) { 'some_parameter' }
-  let(:data_type) { Puppet::Pops::Types::PStringType }
+  let(:data_type) { Puppet::Pops::Types::PStringType.new(nil) }
   let(:resource_hash) { { resource: {} } }
-  let(:result) { 'value' }
-  let(:value) { 'value' }
 
-  it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
-  it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash) }.not_to raise_error }
+  describe '#new(type_name, data_type, attribute_name, resource_hash)' do
+    it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
+    it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash) }.not_to raise_error }
+  end
 
   describe '#value=(value)' do
     context 'when called from `puppet resource`' do
       context 'when the value set attempt is performed' do
         it 'value set fails' do
-          expect { read_only_parameter.value=(value) }.to raise_error( # rubocop:disable Style/RedundantParentheses, Layout/SpaceAroundOperators
+          expect { read_only_parameter.value = 'value' }.to raise_error(
             Puppet::ResourceError,
             %r{Attempting to set `some_parameter` read_only attribute value to `value`},
           )
@@ -29,43 +29,31 @@ RSpec.describe Puppet::ResourceApi::ReadOnlyParameter do
   end
 
   describe '#value' do
-    context 'when value is string' do
-      context 'when the value is set' do
-        before(:each) do
-          allow(described_class).to receive(:value).and_return(result)
-        end
+    context 'when the value is not set' do
+      it 'nil is returned' do
+        expect(read_only_parameter.value).to eq nil
+      end
+    end
 
-        it('value is called') do
-          described_class.value
-          expect(described_class).to have_received(:value).once
-        end
-
-        it('value is returned') do
-          expect(described_class.value).to eq result
-        end
+    context 'when the value is set' do
+      it 'value is returned' do
+        read_only_parameter.instance_variable_set(:@value, 'value')
+        expect(read_only_parameter.value).to eq 'value'
       end
     end
   end
 
   describe '#rs_value' do
     context 'when the value is not set' do
-      it('nil is returned') do
-        expect(read_only_parameter.value).to eq nil
+      it 'nil is returned' do
+        expect(read_only_parameter.rs_value).to eq nil
       end
     end
 
-    context 'when value is string' do
-      context 'when the value is set' do
-        it('value is called') do
-          allow(described_class).to receive(:rs_value).and_return(result)
-          described_class.rs_value
-          expect(described_class).to have_received(:rs_value).once
-        end
-
-        it('value is returned') do
-          read_only_parameter.instance_variable_set(:@value, value)
-          expect(read_only_parameter.rs_value).to eq result
-        end
+    context 'when the value is set' do
+      it 'value is returned' do
+        read_only_parameter.instance_variable_set(:@value, 'value')
+        expect(read_only_parameter.rs_value).to eq 'value'
       end
     end
   end

--- a/spec/puppet/resource_api/read_only_parameter_spec.rb
+++ b/spec/puppet/resource_api/read_only_parameter_spec.rb
@@ -15,46 +15,28 @@ RSpec.describe Puppet::ResourceApi::ReadOnlyParameter do
     it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash) }.not_to raise_error }
   end
 
-  describe '#value=(value)' do
-    context 'when called from `puppet resource`' do
-      context 'when the value set attempt is performed' do
-        it 'value set fails' do
-          expect { read_only_parameter.value = 'value' }.to raise_error(
-            Puppet::ResourceError,
-            %r{Attempting to set `some_parameter` read_only attribute value to `value`},
-          )
-        end
-      end
-    end
-  end
-
-  describe '#value' do
-    context 'when the value is not set' do
-      it 'nil is returned' do
-        expect(read_only_parameter.value).to eq nil
+  describe 'value munging and storage' do
+    context 'when the value set attempt is performed' do
+      it 'value set fails' do
+        expect { read_only_parameter.value = 'value' }.to raise_error(
+          Puppet::ResourceError,
+          %r{Attempting to set `some_parameter` read_only attribute value to `value`},
+        )
       end
     end
 
-    context 'when the value is set' do
-      it 'value is returned' do
+    context 'when value is not set' do
+      it { expect(read_only_parameter.rs_value).to eq nil }
+      it { expect(read_only_parameter.value).to eq nil }
+    end
+
+    context 'when value is already set' do
+      before(:each) do
         read_only_parameter.instance_variable_set(:@value, 'value')
-        expect(read_only_parameter.value).to eq 'value'
       end
-    end
-  end
 
-  describe '#rs_value' do
-    context 'when the value is not set' do
-      it 'nil is returned' do
-        expect(read_only_parameter.rs_value).to eq nil
-      end
-    end
-
-    context 'when the value is set' do
-      it 'value is returned' do
-        read_only_parameter.instance_variable_set(:@value, 'value')
-        expect(read_only_parameter.rs_value).to eq 'value'
-      end
+      it { expect(read_only_parameter.rs_value).to eq 'value' }
+      it { expect(read_only_parameter.value).to eq 'value' }
     end
   end
 end

--- a/spec/puppet/resource_api/value_creator_spec.rb
+++ b/spec/puppet/resource_api/value_creator_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::ValueCreator do
-  subject(:instance) do
-    described_class.new(resource_class, data_type, param_or_property, options)
+  subject(:value_creator) do
+    described_class
   end
 
   let(:resource_class) { Puppet::ResourceApi::Property }
@@ -24,12 +24,12 @@ RSpec.describe Puppet::ResourceApi::ValueCreator do
     allow(resource_class).to receive(:isnamevar)
   end
 
-  it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
-  it { expect { instance }.not_to raise_error }
+  it { expect { described_class.create_values(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
+  it { expect { value_creator }.not_to raise_error }
 
   describe '#create_values' do
     before(:each) do
-      instance.create_values
+      value_creator.create_values(resource_class, data_type, param_or_property, options)
     end
 
     context 'when resource class is property' do
@@ -50,7 +50,7 @@ RSpec.describe Puppet::ResourceApi::ValueCreator do
       end
 
       context 'when property has Boolean type' do
-        let(:data_type) { Puppet::Pops::Types::PBooleanType.new() } # rubocop:disable Style/WordArray
+        let(:data_type) { Puppet::Pops::Types::PBooleanType.new }
         let(:options) do
           {
             type: 'Boolean',
@@ -68,7 +68,7 @@ RSpec.describe Puppet::ResourceApi::ValueCreator do
       end
 
       context 'when property has String type' do
-        let(:data_type) { Puppet::Pops::Types::PStringType.new('s') } # rubocop:disable Style/WordArray
+        let(:data_type) { Puppet::Pops::Types::PStringType.new('s') }
         let(:options) do
           {
             type: 'String',
@@ -82,7 +82,7 @@ RSpec.describe Puppet::ResourceApi::ValueCreator do
       end
 
       context 'when property has Integer type' do
-        let(:data_type) { Puppet::Pops::Types::PIntegerType.new(1) } # rubocop:disable Style/WordArray
+        let(:data_type) { Puppet::Pops::Types::PIntegerType.new(1) }
         let(:options) do
           {
             type: 'Integer',
@@ -96,7 +96,7 @@ RSpec.describe Puppet::ResourceApi::ValueCreator do
       end
 
       context 'when property has Float type' do
-        let(:data_type) { Puppet::Pops::Types::PFloatType.new(1.0) } # rubocop:disable Style/WordArray
+        let(:data_type) { Puppet::Pops::Types::PFloatType.new(1.0) }
         let(:options) do
           {
             type: 'Float',
@@ -112,7 +112,7 @@ RSpec.describe Puppet::ResourceApi::ValueCreator do
 
     context 'when resource class is parameter' do
       let(:resource_class) { Puppet::ResourceApi::Parameter }
-      let(:data_type) { Puppet::Pops::Types::PBooleanType.new() } # rubocop:disable Style/WordArray
+      let(:data_type) { Puppet::Pops::Types::PBooleanType.new }
       let(:param_or_property) { :newparam }
 
       it 'resource_class has no #call_provider method' do
@@ -161,7 +161,7 @@ RSpec.describe Puppet::ResourceApi::ValueCreator do
       end
 
       context 'when parameter has Boolean type' do
-        let(:data_type) { Puppet::Pops::Types::PBooleanType.new() } # rubocop:disable Style/WordArray
+        let(:data_type) { Puppet::Pops::Types::PBooleanType.new }
         let(:options) do
           {
             type: 'Boolean',
@@ -179,7 +179,7 @@ RSpec.describe Puppet::ResourceApi::ValueCreator do
       end
 
       context 'when parameter has String type' do
-        let(:data_type) { Puppet::Pops::Types::PStringType.new('s') } # rubocop:disable Style/WordArray
+        let(:data_type) { Puppet::Pops::Types::PStringType.new('s') }
         let(:options) do
           {
             type: 'String',
@@ -193,7 +193,7 @@ RSpec.describe Puppet::ResourceApi::ValueCreator do
       end
 
       context 'when parameter has Integer type' do
-        let(:data_type) { Puppet::Pops::Types::PIntegerType.new(1) } # rubocop:disable Style/WordArray
+        let(:data_type) { Puppet::Pops::Types::PIntegerType.new(1) }
         let(:options) do
           {
             type: 'Integer',
@@ -207,7 +207,7 @@ RSpec.describe Puppet::ResourceApi::ValueCreator do
       end
 
       context 'when parameter has Float type' do
-        let(:data_type) { Puppet::Pops::Types::PFloatType.new(1.0) } # rubocop:disable Style/WordArray
+        let(:data_type) { Puppet::Pops::Types::PFloatType.new(1.0) }
         let(:options) do
           {
             type: 'Float',

--- a/spec/puppet/resource_api/value_creator_spec.rb
+++ b/spec/puppet/resource_api/value_creator_spec.rb
@@ -1,0 +1,224 @@
+require 'spec_helper'
+
+RSpec.describe Puppet::ResourceApi::ValueCreator do
+  subject(:instance) do
+    described_class.new(resource_class, data_type, param_or_property, options)
+  end
+
+  let(:resource_class) { Puppet::ResourceApi::Property }
+  let(:data_type) { Puppet::Pops::Types::PEnumType.new(['absent', 'present']) } # rubocop:disable Style/WordArray
+  let(:param_or_property) { :newproperty }
+  let(:options) do
+    {
+      type: 'Enum[present, absent]',
+      desc: 'Whether this resource should be present or absent on the target system.',
+      default: 'present',
+    }
+  end
+
+  before(:each) do
+    allow(resource_class).to receive(:newvalue)
+    allow(resource_class).to receive(:newvalues)
+    allow(resource_class).to receive(:aliasvalue)
+    allow(resource_class).to receive(:defaultto)
+    allow(resource_class).to receive(:isnamevar)
+  end
+
+  it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
+  it { expect { instance }.not_to raise_error }
+
+  describe '#create_values' do
+    before(:each) do
+      instance.create_values
+    end
+
+    context 'when resource class is property' do
+      it 'resource_class has #call_provider defined' do
+        expect(resource_class.method_defined?(:call_provider)).to eq(true)
+      end
+
+      context 'when property is :ensure' do
+        it 'calls #newvalue twice' do
+          expect(Puppet::ResourceApi::Property).to have_received(:newvalue).twice
+        end
+      end
+
+      context 'when default is set' do
+        it 'calls #defaultto once' do
+          expect(resource_class).to have_received(:defaultto)
+        end
+      end
+
+      context 'when property has Boolean type' do
+        let(:data_type) { Puppet::Pops::Types::PBooleanType.new() } # rubocop:disable Style/WordArray
+        let(:options) do
+          {
+            type: 'Boolean',
+            desc: 'Boolean test.',
+          }
+        end
+
+        it 'calls #newvalue twice' do
+          expect(resource_class).to have_received(:newvalue).twice
+        end
+
+        it 'calls #aliasvalue four times' do
+          expect(resource_class).to have_received(:aliasvalue).at_least(4).times
+        end
+      end
+
+      context 'when property has String type' do
+        let(:data_type) { Puppet::Pops::Types::PStringType.new('s') } # rubocop:disable Style/WordArray
+        let(:options) do
+          {
+            type: 'String',
+            desc: 'String test.',
+          }
+        end
+
+        it 'calls #newvalue twice' do
+          expect(resource_class).to have_received(:newvalue).once
+        end
+      end
+
+      context 'when property has Integer type' do
+        let(:data_type) { Puppet::Pops::Types::PIntegerType.new(1) } # rubocop:disable Style/WordArray
+        let(:options) do
+          {
+            type: 'Integer',
+            desc: 'Integer test.',
+          }
+        end
+
+        it 'calls #newvalue twice' do
+          expect(resource_class).to have_received(:newvalue).once
+        end
+      end
+
+      context 'when property has Float type' do
+        let(:data_type) { Puppet::Pops::Types::PFloatType.new(1.0) } # rubocop:disable Style/WordArray
+        let(:options) do
+          {
+            type: 'Float',
+            desc: 'Float test.',
+          }
+        end
+
+        it 'calls #newvalue twice' do
+          expect(resource_class).to have_received(:newvalue).once
+        end
+      end
+    end
+
+    context 'when resource class is parameter' do
+      let(:resource_class) { Puppet::ResourceApi::Parameter }
+      let(:data_type) { Puppet::Pops::Types::PBooleanType.new() } # rubocop:disable Style/WordArray
+      let(:param_or_property) { :newparam }
+
+      it 'resource_class has no #call_provider method' do
+        expect(resource_class.method_defined?(:call_provider)).to eq(false)
+      end
+
+      context 'when behaviour is set to :namevar' do
+        let(:options) do
+          {
+            type: 'String',
+            desc: 'Namevar test',
+            behaviour: :namevar,
+          }
+        end
+
+        it 'calls #isnamevar once' do
+          expect(resource_class).to have_received(:isnamevar).once
+        end
+      end
+
+      context 'when default value is set' do
+        let(:options) do
+          {
+            type: 'Boolean',
+            desc: 'Default value test',
+            default: true,
+          }
+        end
+
+        it 'calls #defaultto once' do
+          expect(resource_class).to have_received(:defaultto).once
+        end
+      end
+
+      context 'when there is no default value' do
+        let(:options) do
+          {
+            type: 'Boolean',
+            desc: 'No default value test',
+          }
+        end
+
+        it 'does not call #defaultto' do
+          expect(resource_class).not_to receive(:defaultto)
+        end
+      end
+
+      context 'when parameter has Boolean type' do
+        let(:data_type) { Puppet::Pops::Types::PBooleanType.new() } # rubocop:disable Style/WordArray
+        let(:options) do
+          {
+            type: 'Boolean',
+            desc: 'Boolean test.',
+          }
+        end
+
+        it 'calls #newvalues twice' do
+          expect(resource_class).to have_received(:newvalues).once
+        end
+
+        it 'calls #aliasvalue four times' do
+          expect(resource_class).to have_received(:aliasvalue).at_least(4).times
+        end
+      end
+
+      context 'when parameter has String type' do
+        let(:data_type) { Puppet::Pops::Types::PStringType.new('s') } # rubocop:disable Style/WordArray
+        let(:options) do
+          {
+            type: 'String',
+            desc: 'String test.',
+          }
+        end
+
+        it 'calls #newvalues twice' do
+          expect(resource_class).to have_received(:newvalues).once
+        end
+      end
+
+      context 'when parameter has Integer type' do
+        let(:data_type) { Puppet::Pops::Types::PIntegerType.new(1) } # rubocop:disable Style/WordArray
+        let(:options) do
+          {
+            type: 'Integer',
+            desc: 'Integer test.',
+          }
+        end
+
+        it 'calls #newvalues twice' do
+          expect(resource_class).to have_received(:newvalues).once
+        end
+      end
+
+      context 'when parameter has Float type' do
+        let(:data_type) { Puppet::Pops::Types::PFloatType.new(1.0) } # rubocop:disable Style/WordArray
+        let(:options) do
+          {
+            type: 'Float',
+            desc: 'Float test.',
+          }
+        end
+
+        it 'calls #newvalues twice' do
+          expect(resource_class).to have_received(:newvalues).once
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In this proposal the PR the changes were extraction of parameter logic to:
- `Puppet::ResourceApi::Property`
- `Puppet::ResourceApi::ReadOnlyParameter`
- `Puppet::ResourceApi::Parameter`

and movement of value defaults and aliases logic to

- `Puppet::ResourceApi::ValueCreator`

Commits are in smaller chunks and can be changed / squashed.
@DavidS if you have any changes, suggestions please let me know. I can adjust the code.