### PR TITLE
(packaging) Update version to 1.7.0

### DIFF
--- a/lib/puppet/resource_api/version.rb
+++ b/lib/puppet/resource_api/version.rb
@@ -1,5 +1,5 @@
 module Puppet
   module ResourceApi
-    VERSION = '1.6.2'.freeze
+    VERSION = '1.7.0'.freeze
   end
 end


### PR DESCRIPTION
The puppet-agent release automation assumes repositories know what the
NEXT version of the project will be. This will be maintained
automatically by our automation going forward, but needs to be
manually fixed up this time.