### PR TITLE
(FM-7726) implement `context.transport` to provide access

### DIFF
--- a/lib/puppet/resource_api/base_context.rb
+++ b/lib/puppet/resource_api/base_context.rb
@@ -25,6 +25,10 @@ class Puppet::ResourceApi::BaseContext
     raise 'Received device() on an unprepared BaseContext. Use a PuppetContext instead.'
   end
 
+  def transport
+    raise 'No transport available.'
+  end
+
   def failed?
     @failed
   end

--- a/lib/puppet/resource_api/io_context.rb
+++ b/lib/puppet/resource_api/io_context.rb
@@ -1,11 +1,14 @@
 require 'puppet/resource_api/base_context'
 
 # Implement Resource API Conext to log through an IO object, defaulting to `$stderr`.
-# There is no access to a device here.
+# There is no access to a device here. You can supply a transport if necessary.
 class Puppet::ResourceApi::IOContext < Puppet::ResourceApi::BaseContext
-  def initialize(definition, target = $stderr)
+  attr_reader :transport
+
+  def initialize(definition, target = $stderr, transport = nil)
     super(definition)
     @target = target
+    @transport = transport
   end
 
   protected

--- a/lib/puppet/resource_api/puppet_context.rb
+++ b/lib/puppet/resource_api/puppet_context.rb
@@ -2,12 +2,16 @@ require 'puppet/resource_api/base_context'
 require 'puppet/util/logging'
 
 # Implement Resource API Context to log through Puppet facilities
-# and access/expose the puppet process' current device
+# and access/expose the puppet process' current device/transport
 class Puppet::ResourceApi::PuppetContext < Puppet::ResourceApi::BaseContext
   def device
     # TODO: evaluate facter_url setting for loading config if there is no `current` NetworkDevice
     raise 'no device configured' unless Puppet::Util::NetworkDevice.current
     Puppet::Util::NetworkDevice.current
+  end
+
+  def transport
+    device.transport
   end
 
   def log_exception(exception, message: 'Error encountered', trace: false)

--- a/lib/puppet/resource_api/transport/wrapper.rb
+++ b/lib/puppet/resource_api/transport/wrapper.rb
@@ -4,7 +4,7 @@ require 'hocon/config_syntax'
 
 # Puppet::ResourceApi::Transport::Wrapper` to interface between the Util::NetworkDevice
 class Puppet::ResourceApi::Transport::Wrapper
-  attr_reader :transport
+  attr_reader :transport, :schema
 
   def initialize(name, url_or_config)
     if url_or_config.is_a? String

--- a/spec/fixtures/test_module/lib/puppet/util/network_device/test_device/device.rb
+++ b/spec/fixtures/test_module/lib/puppet/util/network_device/test_device/device.rb
@@ -1,10 +1,10 @@
-require 'puppet/util/network_device/simple/device'
+require 'puppet/resource_api/transport/wrapper'
 
 module Puppet::Util::NetworkDevice::Test_device # rubocop:disable Style/ClassAndModuleCamelCase
-  # A simple test device returning hardcoded facts
-  class Device < Puppet::Util::NetworkDevice::Simple::Device
-    def facts
-      { 'foo' => 'bar' }
+  class Device < Puppet::ResourceApi::Transport::Wrapper
+    def initialize(url_or_config, _options = {})
+      puts url_or_config.inspect
+      super('test_device', url_or_config)
     end
   end
 end

--- a/spec/puppet/resource_api/base_context_spec.rb
+++ b/spec/puppet/resource_api/base_context_spec.rb
@@ -341,6 +341,10 @@ RSpec.describe Puppet::ResourceApi::BaseContext do
     it { expect { described_class.new(definition).device }.to raise_error RuntimeError, %r{Received device\(\) on an unprepared BaseContext\. Use a PuppetContext instead} }
   end
 
+  describe '#transport' do
+    it { expect { described_class.new(definition).transport }.to raise_error RuntimeError, %r{No transport available\.} }
+  end
+
   describe '#send_log' do
     it { expect { described_class.new(definition).send_log(nil, nil) }.to raise_error RuntimeError, %r{Received send_log\(\) on an unprepared BaseContext\. Use IOContext, or PuppetContext instead} }
   end

--- a/spec/puppet/resource_api/io_context_spec.rb
+++ b/spec/puppet/resource_api/io_context_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 require 'puppet/resource_api/io_context'
 
 RSpec.describe Puppet::ResourceApi::IOContext do
-  subject(:context) { described_class.new(definition, io) }
+  subject(:context) { described_class.new(definition, io, transport) }
 
   let(:definition) { { name: 'some_resource', attributes: {} } }
+  let(:transport) { nil }
 
   let(:io) { StringIO.new('', 'w') }
 
@@ -16,6 +17,15 @@ RSpec.describe Puppet::ResourceApi::IOContext do
     it 'outputs at the correct level' do
       context.warning('message')
       expect(io.string).to match %r{warning}i
+    end
+  end
+
+  describe '#transport' do
+    it { expect(context.transport).to be_nil }
+    context 'when passing in a transport' do
+      let(:transport) { instance_double(Object, 'transport') }
+
+      it { expect(context.transport).to eq transport }
     end
   end
 end

--- a/spec/puppet/resource_api/puppet_context_spec.rb
+++ b/spec/puppet/resource_api/puppet_context_spec.rb
@@ -18,7 +18,21 @@ RSpec.describe Puppet::ResourceApi::PuppetContext do
       end
     end
 
-    context 'with no NetworkDevice configured' do
+    context 'when a Transport::Wrapper device is configured' do
+      let(:device) { instance_double('Puppet::Util::NetworkDevice::Test_device::Device', 'device') }
+      let(:transport) { instance_double('Puppet::Transport::TestDevice', 'transport') }
+
+      before(:each) do
+        allow(Puppet::Util::NetworkDevice).to receive(:current).and_return(device)
+        allow(device).to receive(:transport).and_return(transport)
+      end
+
+      it 'returns the transport' do
+        expect(context.transport).to eq(transport)
+      end
+    end
+
+    context 'with nothing configured' do
       before(:each) do
         allow(Puppet::Util::NetworkDevice).to receive(:current).and_return(nil)
       end


### PR DESCRIPTION
Using this accessor providers can talk directly to the transport
without having to go through the `Device` at all.