### PR TITLE
(PA-2496) Bump version and remove v from version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ To do so, follow these instructions from a current `master` checkout:
   * run `rake changelog`
   * double check the PRs to make sure they're all tagged correctly (using the new CHANGELOG for cross-checking)
 * Check README and other materials for up-to-date-ness
-* Commit changes with title "Release prep for v\<VERSION>"
+* Commit changes with title "Release prep for \<VERSION>"
 * Upload and PR the release-prep branch to the puppetlabs GitHub repo
 * Check that CI is green and merge the PR
 * Run `rake release[upstream]` to release from your checkout

--- a/lib/puppet/resource_api/version.rb
+++ b/lib/puppet/resource_api/version.rb
@@ -1,5 +1,5 @@
 module Puppet
   module ResourceApi
-    VERSION = '1.8.2'.freeze
+    VERSION = '1.8.3'.freeze
   end
 end

--- a/misc/ANNOUNCEMENT_TEMPLATE.md
+++ b/misc/ANNOUNCEMENT_TEMPLATE.md
@@ -22,7 +22,7 @@ See [this post](https://groups.google.com/d/msg/puppet-dev/1R9gwkEIxHU/adWXJ0NfC
 
 ---
 
-Subject: [ANN] Resource API vX.Y.Z Release
+Subject: [ANN] Resource API X.Y.Z Release
 
 Hi all,
 


### PR DESCRIPTION
Hopefully this is the last manual bump to the Resource API version.

This PR bumps to the next version and also removes the "v" from version number