### PR TITLE
(maint) Fixup Gemfile for JRuby 1.7 installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       cache:
         bundler: true
         directories: ~/.rvm
-      before_install: rvm use jruby-1.7.26 --install --binary --fuzzy
+      before_install: rvm use jruby-1.7.26 --install --binary --fuzzy && gem install bundler -v '~> 1.7.0'
     # disable coverage on jruby9k as this confuses codecov
     - env: RVM="jruby-9.1.9.0" PUPPET_GEM_VERSION='~> 5' JRUBY_OPTS="--debug"
       before_cache: pushd ~/.rvm && rm -rf archives rubies/ruby-2.2.7 rubies/ruby-2.3.4 && popd

--- a/Gemfile
+++ b/Gemfile
@@ -7,15 +7,13 @@ gemspec
 
 group :tests do
   gem 'codecov'
-  # license_finder does not install on windows using older versions of rubygems.
-  # ruby 2.4 is confirmed working on appveyor.
-  gem 'license_finder' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3.0'
   # rubocop 0.58 throws when testing against ruby 2.1, so pin to the latest,
   # unless we're dealing with jruby...
   if RUBY_PLATFORM == 'java'
     # load any rubocop version that works on java for the Rakefile
+    gem 'parser', '2.3.3.1'
     gem 'rubocop', '0.41.2'
   elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.0')
     gem 'rubocop', '0.57.2'
@@ -27,6 +25,9 @@ group :tests do
     # This needs to be removed once we drop puppet4 support.
     gem 'rubocop', '~> 0.57.0'
     gem 'rubocop-rspec'
+    # license_finder does not install on windows using older versions of rubygems.
+    # ruby 2.4 is confirmed working on appveyor.
+    gem 'license_finder' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
   end
   gem 'simplecov-console'
   # the test gems required for module testing


### PR DESCRIPTION
These changes enable the current JRuby 1.7 build to complete. It appears that the current `master` branch is using a cache which has hidden the failures, which are evident when building against a new fork. 