### PR TITLE
(MODULES-9428) make the composite namevar implementation usable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,6 @@ end
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec) do |t|
-  Rake::Task[:spec_prep].invoke
   # thanks to the fixtures/modules/ symlinks this needs to exclude fixture modules explicitely
   excludes = ['fixtures/**/*.rb,fixtures/modules/*/**/*.rb']
   if RUBY_PLATFORM == 'java'
@@ -24,12 +23,20 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.exclude_pattern = "spec/{#{excludes.join ','}}"
 end
 
+task :spec => :spec_prep
+
 namespace :spec do
   desc 'Run RSpec code examples with coverage collection'
   task :coverage do
     ENV['SIMPLECOV'] = 'yes'
     Rake::Task['spec'].execute
   end
+
+  RSpec::Core::RakeTask.new(:unit) do |t|
+    t.pattern = "spec/puppet/**/*_spec.rb,spec/integration/**/*_spec.rb"
+  end
+
+  task :unit => :spec_prep
 end
 
 #### LICENSE_FINDER ####

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   if RUBY_PLATFORM == 'java'
     excludes += ['acceptance/**/*.rb', 'integration/**/*.rb', 'puppet/resource_api/*_context_spec.rb', 'puppet/util/network_device/simple/device_spec.rb']
     t.rspec_opts = '--tag ~agent_test'
+    t.rspec_opts << ' --tag ~j17_exclude' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
   end
   t.exclude_pattern = "spec/{#{excludes.join ','}}"
 end

--- a/lib/puppet/resource_api/glue.rb
+++ b/lib/puppet/resource_api/glue.rb
@@ -57,4 +57,19 @@ module Puppet::ResourceApi
       values.keys.reject { |k| k == :title || !attr_def[k] || (attr_def[k][:behaviour] == :namevar && @namevars.size == 1) }
     end
   end
+
+  # this hash allows key-value based ordering comparisons between instances of this and instances of this and other classes
+  # this is required for `lib/puppet/indirector/resource/ral.rb`'s `search` method which expects all titles to be comparable
+  class MonkeyHash < Hash
+    def <=>(other)
+      result = self.class.name <=> other.class.name
+      if result.zero?
+        result = keys.sort <=> other.keys.sort
+      end
+      if result.zero?
+        result = keys.sort.map { |k| self[k] } <=> other.keys.sort.map { |k| other[k] }
+      end
+      result
+    end
+  end
 end

--- a/lib/puppet/resource_api/simple_provider.rb
+++ b/lib/puppet/resource_api/simple_provider.rb
@@ -1,4 +1,5 @@
 module Puppet; end # rubocop:disable Style/Documentation
+
 module Puppet::ResourceApi
   # This class provides a default implementation for set(), when your resource does not benefit from batching.
   # Instead of processing changes yourself, the `create`, `update`, and `delete` functions, are called for you,
@@ -19,12 +20,12 @@ module Puppet::ResourceApi
 
         raise 'SimpleProvider cannot be used with a Type that is not ensurable' unless context.type.ensurable?
 
-        is = { name: name, ensure: 'absent' } if is.nil?
-        should = { name: name, ensure: 'absent' } if should.nil?
+        is = SimpleProvider.create_absent(:name, name) if is.nil?
+        should = SimpleProvider.create_absent(:name, name) if should.nil?
 
         name_hash = if context.type.namevars.length > 1
                       # pass a name_hash containing the values of all namevars
-                      name_hash = { title: name }
+                      name_hash = {}
                       context.type.namevars.each do |namevar|
                         name_hash[namevar] = change[:should][namevar]
                       end
@@ -59,6 +60,17 @@ module Puppet::ResourceApi
 
     def delete(_context, _name)
       raise "#{self.class} has not implemented `delete`"
+    end
+
+    # @api private
+    def self.create_absent(namevar, title)
+      result = if title.is_a? Hash
+                 title.dup
+               else
+                 { namevar => title }
+               end
+      result[:ensure] = 'absent'
+      result
     end
   end
 end

--- a/spec/acceptance/composite_namevar_spec.rb
+++ b/spec/acceptance/composite_namevar_spec.rb
@@ -1,5 +1,6 @@
-require 'spec_helper'
 require 'open3'
+require 'spec_helper'
+require 'tempfile'
 
 RSpec.describe 'a type with composite namevars' do
   let(:common_args) { '--verbose --trace --debug --strict=error --modulepath spec/fixtures' }
@@ -8,6 +9,7 @@ RSpec.describe 'a type with composite namevars' do
     it 'is returns the values correctly' do
       stdout_str, status = Open3.capture2e("puppet resource #{common_args} composite_namevar")
       expect(stdout_str.strip).to match %r{^composite_namevar}
+      expect(stdout_str.strip).to match %r{Looking for \[\]}
       expect(status).to eq 0
     end
     it 'returns the required resource correctly' do
@@ -16,23 +18,27 @@ RSpec.describe 'a type with composite namevars' do
       expect(stdout_str.strip).to match %r{ensure\s*=> \'present\'}
       expect(stdout_str.strip).to match %r{package\s*=> \'php\'}
       expect(stdout_str.strip).to match %r{manager\s*=> \'yum\'}
+      expect(stdout_str.strip).to match %r{Looking for \[\]}
       expect(status.exitstatus).to eq 0
     end
-    it 'Throws error if title is not a matching title_pattern' do
-      stdout_str, status = Open3.capture2e("puppet resource #{common_args} composite_namevar php package=php manager=yum")
-      expect(stdout_str.strip).to match %r{No set of title patterns matched the title "php"}
+    it 'throws error if title is not a matching title_pattern' do
+      stdout_str, status = Open3.capture2e("puppet resource #{common_args} composite_namevar php123 package=php manager=yum")
+      expect(stdout_str.strip).to match %r{No set of title patterns matched the title "php123"}
+      expect(stdout_str.strip).not_to match %r{Looking for}
       expect(status.exitstatus).to eq 1
     end
     it 'returns the match if alternative title_pattern matches' do
       stdout_str, status = Open3.capture2e("puppet resource #{common_args} composite_namevar php/gem")
       expect(stdout_str.strip).to match %r{^composite_namevar \{ \'php/gem\'}
       expect(stdout_str.strip).to match %r{ensure\s*=> \'present\'}
+      expect(stdout_str.strip).to match %r{Looking for \["php/gem"\]}
       expect(status.exitstatus).to eq 0
     end
     it 'properly identifies an absent resource if only the title is provided' do
       stdout_str, status = Open3.capture2e("puppet resource #{common_args} composite_namevar php-wibble")
       expect(stdout_str.strip).to match %r{^composite_namevar \{ \'php-wibble\'}
       expect(stdout_str.strip).to match %r{ensure\s*=> \'absent\'}
+      expect(stdout_str.strip).to match %r{Looking for \["php-wibble"\]}
       expect(status.exitstatus).to eq 0
     end
     it 'creates a previously absent resource' do
@@ -41,6 +47,7 @@ RSpec.describe 'a type with composite namevars' do
       expect(stdout_str.strip).to match %r{ensure\s*=> \'present\'}
       expect(stdout_str.strip).to match %r{package\s*=> \'php\'}
       expect(stdout_str.strip).to match %r{manager\s*=> \'wibble\'}
+      expect(stdout_str.strip).to match %r{Looking for \["php-wibble"\]}
       expect(status.exitstatus).to eq 0
     end
     it 'will remove an existing resource' do
@@ -49,16 +56,16 @@ RSpec.describe 'a type with composite namevars' do
       expect(stdout_str.strip).to match %r{package\s*=> \'php\'}
       expect(stdout_str.strip).to match %r{manager\s*=> \'gem\'}
       expect(stdout_str.strip).to match %r{ensure\s*=> \'absent\'}
+      expect(stdout_str.strip).to match %r{Looking for \["php-gem"\]}
       expect(status.exitstatus).to eq 0
     end
   end
 
   describe 'using `puppet apply`' do
-    require 'tempfile'
-
     let(:common_args) { super() + ' --detailed-exitcodes' }
 
-    # run Open3.capture2e only once to get both output, and exitcode # rubocop:disable RSpec/InstanceVariable
+    # run Open3.capture2e only once to get both output, and exitcode
+    # rubocop:disable RSpec/InstanceVariable
     before(:each) do
       Tempfile.create('acceptance') do |f|
         f.write(manifest)
@@ -67,42 +74,82 @@ RSpec.describe 'a type with composite namevars' do
       end
     end
 
-    context 'when managing a present instance' do
-      let(:manifest) { 'composite_namevar { php-gem: }' }
+    context 'when matching title patterns' do
+      context 'when managing a present instance' do
+        let(:manifest) { 'composite_namevar { php-gem: }' }
 
-      it { expect(@stdout_str).to match %r{Current State: \{:title=>"php-gem", :package=>"php", :manager=>"gem", :ensure=>"present", :value=>"b"\}} }
-      it { expect(@status.exitstatus).to eq 0 }
+        it { expect(@stdout_str).to match %r{Current State: \{:title=>"php-gem", :package=>"php", :manager=>"gem", :ensure=>"present", :value=>"b"\}} }
+        it { expect(@stdout_str).to match %r{Looking for \["php-gem"\]} }
+        it { expect(@status.exitstatus).to eq 0 }
+      end
+
+      context 'when managing an absent instance' do
+        let(:manifest) { 'composite_namevar { php-wibble: ensure=>\'absent\' }' }
+
+        it { expect(@stdout_str).to match %r{Composite_namevar\[php-wibble\]: Nothing to manage: no ensure and the resource doesn't exist} }
+        it { expect(@stdout_str).to match %r{Looking for \["php-wibble"\]} }
+        it { expect(@status.exitstatus).to eq 0 }
+      end
+
+      context 'when creating a previously absent instance' do
+        let(:manifest) { 'composite_namevar { php-wibble: ensure=>\'present\' }' }
+
+        it { expect(@stdout_str).to match %r{Composite_namevar\[php-wibble\]/ensure: defined 'ensure' as 'present'} }
+        it { expect(@stdout_str).to match %r{Looking for \["php-wibble"\]} }
+        it { expect(@status.exitstatus).to eq 2 }
+      end
+
+      context 'when removing a previously present instance' do
+        let(:manifest) { 'composite_namevar { php-yum: ensure=>\'absent\' }' }
+
+        it { expect(@stdout_str).to match %r{Composite_namevar\[php-yum\]/ensure: undefined 'ensure' from 'present'} }
+        it { expect(@stdout_str).to match %r{Looking for \["php-yum"\]} }
+        it { expect(@status.exitstatus).to eq 2 }
+      end
+
+      context 'when modifying an existing resource through an alternative title_pattern' do
+        let(:manifest) { 'composite_namevar { \'php/gem\': value=>\'c\' }' }
+
+        it { expect(@stdout_str).to match %r{Current State: \{:title=>"php-gem", :package=>"php", :manager=>"gem", :ensure=>"present", :value=>"b"\}} }
+        it { expect(@stdout_str).to match %r{Target State: \{:package=>"php", :manager=>"gem", :value=>"c", :ensure=>"present"\}} }
+        it { expect(@stdout_str).to match %r{Looking for \["php/gem"\]} }
+        it { expect(@status.exitstatus).to eq 2 }
+      end
     end
 
-    context 'when managing an absent instance' do
-      let(:manifest) { 'composite_namevar { php-wibble: ensure=>\'absent\' }' }
+    context 'when using attributes' do
+      context 'when managing a present instance' do
+        let(:manifest) { 'composite_namevar { "sometitle": package => "php", manager => "gem" }' }
 
-      it { expect(@stdout_str).to match %r{Composite_namevar\[php-wibble\]: Nothing to manage: no ensure and the resource doesn't exist} }
-      it { expect(@status.exitstatus).to eq 0 }
+        it { expect(@stdout_str).to match %r{Current State: \{:title=>"php-gem", :package=>"php", :manager=>"gem", :ensure=>"present", :value=>"b"\}} }
+        it { expect(@stdout_str).to match %r{Looking for \["sometitle"\]} }
+        it { expect(@status.exitstatus).to eq 0 }
+      end
+
+      context 'when managing an absent instance' do
+        let(:manifest) { 'composite_namevar { "sometitle": ensure => "absent", package => "php", manager => "wibble" }' }
+
+        it { expect(@stdout_str).to match %r{Composite_namevar\[sometitle\]: Nothing to manage: no ensure and the resource doesn't exist} }
+        it { expect(@stdout_str).to match %r{Looking for \["sometitle"\]} }
+        it { expect(@status.exitstatus).to eq 0 }
+      end
+
+      context 'when creating a previously absent instance' do
+        let(:manifest) { 'composite_namevar { "sometitle": ensure => "present", package => "php", manager => "wibble" }' }
+
+        it { expect(@stdout_str).to match %r{Composite_namevar\[sometitle\]/ensure: defined 'ensure' as 'present'} }
+        it { expect(@stdout_str).to match %r{Looking for \["sometitle"\]} }
+        it { expect(@status.exitstatus).to eq 2 }
+      end
+
+      context 'when removing a previously present instance' do
+        let(:manifest) { 'composite_namevar { "sometitle": ensure => "absent", package => "php", manager => "yum" }' }
+
+        it { expect(@stdout_str).to match %r{Composite_namevar\[sometitle\]/ensure: undefined 'ensure' from 'present'} }
+        it { expect(@stdout_str).to match %r{Looking for \["sometitle"\]} }
+        it { expect(@status.exitstatus).to eq 2 }
+      end
     end
-
-    context 'when creating a previously absent instance' do
-      let(:manifest) { 'composite_namevar { php-wibble: ensure=>\'present\' }' }
-
-      it { expect(@stdout_str).to match %r{Composite_namevar\[php-wibble\]/ensure: defined 'ensure' as 'present'} }
-      it { expect(@status.exitstatus).to eq 2 }
-    end
-
-    context 'when removing a previously present instance' do
-      let(:manifest) { 'composite_namevar { php-yum: ensure=>\'absent\' }' }
-
-      it { expect(@stdout_str).to match %r{Composite_namevar\[php-yum\]/ensure: undefined 'ensure' from 'present'} }
-      it { expect(@status.exitstatus).to eq 2 }
-    end
-
-    context 'when modifying an existing resource through an alternative title_pattern' do
-      let(:manifest) { 'composite_namevar { \'php/gem\': value=>\'c\' }' }
-
-      it { expect(@stdout_str).to match %r{Current State: \{:title=>"php-gem", :package=>"php", :manager=>"gem", :ensure=>"present", :value=>"b"\}} }
-      it { expect(@stdout_str).to match %r{Target State: \{:package=>"php", :manager=>"gem", :value=>"c", :ensure=>"present"\}} }
-      it { expect(@status.exitstatus).to eq 2 }
-    end
-
     # rubocop:enable RSpec/InstanceVariable
   end
 end

--- a/spec/acceptance/composite_namevar_spec.rb
+++ b/spec/acceptance/composite_namevar_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe 'a type with composite namevars' do
       stdout_str, status = Open3.capture2e("puppet resource #{common_args} composite_namevar php/gem")
       expect(stdout_str.strip).to match %r{^composite_namevar \{ \'php/gem\'}
       expect(stdout_str.strip).to match %r{ensure\s*=> \'present\'}
-      expect(stdout_str.strip).to match %r{Looking for \["php/gem"\]}
+      expect(stdout_str.strip).to match %r{Looking for \[\{:package=>"php", :manager=>"gem"\}\]}
       expect(status.exitstatus).to eq 0
     end
     it 'properly identifies an absent resource if only the title is provided' do
       stdout_str, status = Open3.capture2e("puppet resource #{common_args} composite_namevar php-wibble")
       expect(stdout_str.strip).to match %r{^composite_namevar \{ \'php-wibble\'}
       expect(stdout_str.strip).to match %r{ensure\s*=> \'absent\'}
-      expect(stdout_str.strip).to match %r{Looking for \["php-wibble"\]}
+      expect(stdout_str.strip).to match %r{Looking for \[\{:package=>"php", :manager=>"wibble"\}\]}
       expect(status.exitstatus).to eq 0
     end
     it 'creates a previously absent resource' do
@@ -47,7 +47,7 @@ RSpec.describe 'a type with composite namevars' do
       expect(stdout_str.strip).to match %r{ensure\s*=> \'present\'}
       expect(stdout_str.strip).to match %r{package\s*=> \'php\'}
       expect(stdout_str.strip).to match %r{manager\s*=> \'wibble\'}
-      expect(stdout_str.strip).to match %r{Looking for \["php-wibble"\]}
+      expect(stdout_str.strip).to match %r{Looking for \[\{:package=>"php", :manager=>"wibble"\}\]}
       expect(status.exitstatus).to eq 0
     end
     it 'will remove an existing resource' do
@@ -56,7 +56,7 @@ RSpec.describe 'a type with composite namevars' do
       expect(stdout_str.strip).to match %r{package\s*=> \'php\'}
       expect(stdout_str.strip).to match %r{manager\s*=> \'gem\'}
       expect(stdout_str.strip).to match %r{ensure\s*=> \'absent\'}
-      expect(stdout_str.strip).to match %r{Looking for \["php-gem"\]}
+      expect(stdout_str.strip).to match %r{Looking for \[\{:package=>"php", :manager=>"gem"\}\]}
       expect(status.exitstatus).to eq 0
     end
   end
@@ -79,7 +79,7 @@ RSpec.describe 'a type with composite namevars' do
         let(:manifest) { 'composite_namevar { php-gem: }' }
 
         it { expect(@stdout_str).to match %r{Current State: \{:title=>"php-gem", :package=>"php", :manager=>"gem", :ensure=>"present", :value=>"b"\}} }
-        it { expect(@stdout_str).to match %r{Looking for \["php-gem"\]} }
+        it { expect(@stdout_str).to match %r{Looking for \[\{:package=>"php", :manager=>"gem"\}\]} }
         it { expect(@status.exitstatus).to eq 0 }
       end
 
@@ -87,7 +87,7 @@ RSpec.describe 'a type with composite namevars' do
         let(:manifest) { 'composite_namevar { php-wibble: ensure=>\'absent\' }' }
 
         it { expect(@stdout_str).to match %r{Composite_namevar\[php-wibble\]: Nothing to manage: no ensure and the resource doesn't exist} }
-        it { expect(@stdout_str).to match %r{Looking for \["php-wibble"\]} }
+        it { expect(@stdout_str).to match %r{Looking for \[\{:package=>"php", :manager=>"wibble"\}\]} }
         it { expect(@status.exitstatus).to eq 0 }
       end
 
@@ -95,7 +95,7 @@ RSpec.describe 'a type with composite namevars' do
         let(:manifest) { 'composite_namevar { php-wibble: ensure=>\'present\' }' }
 
         it { expect(@stdout_str).to match %r{Composite_namevar\[php-wibble\]/ensure: defined 'ensure' as 'present'} }
-        it { expect(@stdout_str).to match %r{Looking for \["php-wibble"\]} }
+        it { expect(@stdout_str).to match %r{Looking for \[\{:package=>"php", :manager=>"wibble"\}\]} }
         it { expect(@status.exitstatus).to eq 2 }
       end
 
@@ -103,7 +103,7 @@ RSpec.describe 'a type with composite namevars' do
         let(:manifest) { 'composite_namevar { php-yum: ensure=>\'absent\' }' }
 
         it { expect(@stdout_str).to match %r{Composite_namevar\[php-yum\]/ensure: undefined 'ensure' from 'present'} }
-        it { expect(@stdout_str).to match %r{Looking for \["php-yum"\]} }
+        it { expect(@stdout_str).to match %r{Looking for \[\{:package=>"php", :manager=>"yum"\}\]} }
         it { expect(@status.exitstatus).to eq 2 }
       end
 
@@ -112,7 +112,7 @@ RSpec.describe 'a type with composite namevars' do
 
         it { expect(@stdout_str).to match %r{Current State: \{:title=>"php-gem", :package=>"php", :manager=>"gem", :ensure=>"present", :value=>"b"\}} }
         it { expect(@stdout_str).to match %r{Target State: \{:package=>"php", :manager=>"gem", :value=>"c", :ensure=>"present"\}} }
-        it { expect(@stdout_str).to match %r{Looking for \["php/gem"\]} }
+        it { expect(@stdout_str).to match %r{Looking for \[\{:package=>"php", :manager=>"gem"\}\]} }
         it { expect(@status.exitstatus).to eq 2 }
       end
     end
@@ -122,7 +122,7 @@ RSpec.describe 'a type with composite namevars' do
         let(:manifest) { 'composite_namevar { "sometitle": package => "php", manager => "gem" }' }
 
         it { expect(@stdout_str).to match %r{Current State: \{:title=>"php-gem", :package=>"php", :manager=>"gem", :ensure=>"present", :value=>"b"\}} }
-        it { expect(@stdout_str).to match %r{Looking for \["sometitle"\]} }
+        it { expect(@stdout_str).to match %r{Looking for \[\{:package=>"php", :manager=>"gem"\}\]} }
         it { expect(@status.exitstatus).to eq 0 }
       end
 
@@ -130,7 +130,7 @@ RSpec.describe 'a type with composite namevars' do
         let(:manifest) { 'composite_namevar { "sometitle": ensure => "absent", package => "php", manager => "wibble" }' }
 
         it { expect(@stdout_str).to match %r{Composite_namevar\[sometitle\]: Nothing to manage: no ensure and the resource doesn't exist} }
-        it { expect(@stdout_str).to match %r{Looking for \["sometitle"\]} }
+        it { expect(@stdout_str).to match %r{Looking for \[\{:package=>"php", :manager=>"wibble"\}\]} }
         it { expect(@status.exitstatus).to eq 0 }
       end
 
@@ -138,7 +138,7 @@ RSpec.describe 'a type with composite namevars' do
         let(:manifest) { 'composite_namevar { "sometitle": ensure => "present", package => "php", manager => "wibble" }' }
 
         it { expect(@stdout_str).to match %r{Composite_namevar\[sometitle\]/ensure: defined 'ensure' as 'present'} }
-        it { expect(@stdout_str).to match %r{Looking for \["sometitle"\]} }
+        it { expect(@stdout_str).to match %r{Looking for \[\{:package=>"php", :manager=>"wibble"\}\]} }
         it { expect(@status.exitstatus).to eq 2 }
       end
 
@@ -146,7 +146,7 @@ RSpec.describe 'a type with composite namevars' do
         let(:manifest) { 'composite_namevar { "sometitle": ensure => "absent", package => "php", manager => "yum" }' }
 
         it { expect(@stdout_str).to match %r{Composite_namevar\[sometitle\]/ensure: undefined 'ensure' from 'present'} }
-        it { expect(@stdout_str).to match %r{Looking for \["sometitle"\]} }
+        it { expect(@stdout_str).to match %r{Looking for \[\{:package=>"php", :manager=>"yum"\}\]} }
         it { expect(@status.exitstatus).to eq 2 }
       end
     end

--- a/spec/acceptance/namevar_spec.rb
+++ b/spec/acceptance/namevar_spec.rb
@@ -24,11 +24,12 @@ RSpec.describe 'a type with multiple namevars' do
       expect(stdout_str.strip).to match %r{ensure\s*=> \'present\'}
       expect(status).to eq 0
     end
-    it 'returns the match if title matches a namevar value' do
-      stdout_str, status = Open3.capture2e("puppet resource #{common_args} multiple_namevar php")
-      expect(stdout_str.strip).to match %r{^multiple_namevar \{ \'php\'}
+    it 'returns the match if title matches a title value' do
+      stdout_str, status = Open3.capture2e("puppet resource #{common_args} multiple_namevar php-gem")
+      expect(stdout_str.strip).to match %r{^multiple_namevar \{ \'php-gem\'}
       expect(stdout_str.strip).to match %r{ensure\s*=> \'present\'}
       expect(stdout_str.strip).to match %r{package\s*=> \'php\'}
+      expect(stdout_str.strip).to match %r{manager\s*=> \'gem\'}
       expect(status).to eq 0
     end
     it 'creates a previously absent resource if all namevars are provided' do

--- a/spec/fixtures/test_module/lib/puppet/provider/composite_namevar/composite_namevar.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/composite_namevar/composite_namevar.rb
@@ -1,7 +1,7 @@
 require 'puppet/resource_api'
 require 'puppet/resource_api/simple_provider'
 
-# Implementation for the title_provider type using the Resource API.
+# Implementation for the composite_namevar type using the Resource API.
 class Puppet::Provider::CompositeNamevar::CompositeNamevar < Puppet::ResourceApi::SimpleProvider
   def initialize
     @current_values ||= [

--- a/spec/fixtures/test_module/lib/puppet/provider/composite_namevar/composite_namevar.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/composite_namevar/composite_namevar.rb
@@ -14,7 +14,8 @@ class Puppet::Provider::CompositeNamevar::CompositeNamevar < Puppet::ResourceApi
     ]
   end
 
-  def get(_context)
+  def get(context, names = nil)
+    context.notice("Looking for #{names.inspect}")
     @current_values
   end
 

--- a/spec/fixtures/test_module/lib/puppet/provider/multiple_namevar/multiple_namevar.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/multiple_namevar/multiple_namevar.rb
@@ -4,12 +4,12 @@ require 'puppet/resource_api'
 class Puppet::Provider::MultipleNamevar::MultipleNamevar
   def initialize
     @current_values ||= [
-      { package: 'php', manager: 'yum', ensure: 'present' },
-      { package: 'php', manager: 'gem', ensure: 'present' },
-      { package: 'mysql', manager: 'yum', ensure: 'present' },
-      { package: 'mysql', manager: 'gem', ensure: 'present' },
-      { package: 'foo', manager: 'bar', ensure: 'present' },
-      { package: 'bar', manager: 'foo', ensure: 'present' },
+      { title: 'php-yum', package: 'php', manager: 'yum', ensure: 'present' },
+      { title: 'php-gem', package: 'php', manager: 'gem', ensure: 'present' },
+      { title: 'mysql-yum', package: 'mysql', manager: 'yum', ensure: 'present' },
+      { title: 'mysql-gem', package: 'mysql', manager: 'gem', ensure: 'present' },
+      { title: 'foo-bar', package: 'foo', manager: 'bar', ensure: 'present' },
+      { title: 'bar-foo', package: 'bar', manager: 'foo', ensure: 'present' },
     ]
   end
 

--- a/spec/fixtures/test_module/lib/puppet/type/composite_namevar.rb
+++ b/spec/fixtures/test_module/lib/puppet/type/composite_namevar.rb
@@ -5,6 +5,7 @@ Puppet::ResourceApi.register_type(
   docs: <<-DOC,
     This type provides Puppet with the capabilities to manage ...
   DOC
+  features: [ 'simple_get_filter' ],
   title_patterns: [
     {
       pattern: %r{^(?<package>.*[^-])-(?<manager>.*)$},
@@ -13,6 +14,10 @@ Puppet::ResourceApi.register_type(
     {
       pattern: %r{^(?<package>.*[^/])/(?<manager>.*)$},
       desc: 'Where the package and the manager are provided with a forward slash separator',
+    },
+    {
+      pattern: %r{^(?<package>[a-z]*[^/])$},
+      desc: 'Fallback pattern where only the package is provided',
     },
   ],
   attributes:   {

--- a/spec/integration/resource_api_spec.rb
+++ b/spec/integration/resource_api_spec.rb
@@ -7,11 +7,26 @@ RSpec.describe 'Resource API integrated tests:' do
     let(:definition) do
       {
         name: 'integration',
+        title_patterns: [
+          {
+            pattern: %r{^(?<name>.*[^-])-(?<name2>.*)$},
+            desc: 'Where the name and the name2 are provided with a hyphen separator',
+          },
+          {
+            pattern: %r{^(?<name>.*)$},
+            desc: 'Where only the name is provided',
+          },
+        ],
         attributes: {
           name: {
             type: 'String',
             behaviour: :namevar,
             desc: 'the title',
+          },
+          name2: {
+            type: 'String',
+            behaviour: :namevar,
+            desc: 'the other title',
           },
           string: {
             type: 'String',
@@ -170,7 +185,18 @@ RSpec.describe 'Resource API integrated tests:' do
       s = setter
       Class.new do
         def get(_context)
-          []
+          [
+            {
+              name: 'foo',
+              name2: 'bar',
+              title: 'foo-bar',
+            },
+            {
+              name: 'foo2',
+              name2: 'bar2',
+              title: 'foo2-bar2',
+            },
+          ]
         end
 
         attr_reader :last_changes
@@ -198,7 +224,7 @@ RSpec.describe 'Resource API integrated tests:' do
       # See spec/acceptance/metaparam_spec.rb for more in-depth testing with a full puppet apply
       let(:catalog) { instance_double('Puppet::Resource::Catalog', 'catalog') }
       let(:instance) do
-        type.new(name: 'somename', ensure: 'present', boolean: true, integer: 15, float: 1.23,
+        type.new(name: 'somename', name2: 'othername', ensure: 'present', boolean: true, integer: 15, float: 1.23,
                  variant_pattern: '0x1234ABCD', url: 'http://www.google.com', sensitive: Puppet::Pops::Types::PSensitiveType::Sensitive.new('a password'),
                  string_array: %w[a b c],
                  variant_array: 'not_an_array', array_of_arrays: [%w[a b c], %w[d e f]],
@@ -225,7 +251,7 @@ RSpec.describe 'Resource API integrated tests:' do
         end
 
         it 'can serialize to json' do
-          expect({ 'resources' => [instance.to_resource] }.to_json).to eq '{"resources":[{"somename":{"ensure":"absent","boolean_param":false,"integer_param":99,"float_param":3.21,"ensure_param":"present","variant_pattern_param":"1234ABCD","url_param":"http://www.puppet.com","string_array_param":"d","e":"f","string_param":"default value"}}]}' # rubocop:disable Metrics/LineLength
+          expect({ 'resources' => [instance.to_resource] }.to_json).to eq '{"resources":[{"somename":{"name":"somename","name2":"othername","ensure":"absent","boolean_param":false,"integer_param":99,"float_param":3.21,"ensure_param":"present","variant_pattern_param":"1234ABCD","url_param":"http://www.puppet.com","string_array_param":"d","e":"f","string_param":"default value"}}]}' # rubocop:disable Metrics/LineLength
         end
       end
 

--- a/spec/puppet/resource_api/glue_spec.rb
+++ b/spec/puppet/resource_api/glue_spec.rb
@@ -78,4 +78,20 @@ RSpec.describe 'the dirty bits' do
       it { expect(instance.to_hash).to eq(namevarname: 'title', attr: 'value', attr_ro: 'fixed') }
     end
   end
+
+  describe Puppet::ResourceApi::MonkeyHash do
+    it { expect(described_class.ancestors).to include Hash }
+
+    describe '#<=>(other)' do
+      subject(:value) { described_class[b: 'b', c: 'c'] }
+
+      it { expect(value <=> 'string').to eq(-1) }
+      # Avoid this test on jruby 1.7, where it is hitting a implementation inconsistency and `'string' <=> value` returns `nil`
+      it('compares to a string', j17_exclude: true) { expect('string' <=> value).to eq 1 }
+      it { expect(value <=> described_class[b: 'b', c: 'c']).to eq 0 }
+      it { expect(value <=> described_class[d: 'd']).to eq(-1) }
+      it { expect(value <=> described_class[a: 'a']).to eq 1 }
+      it { expect(value <=> described_class[b: 'a', c: 'c']).to eq 1 }
+    end
+  end
 end

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -1133,7 +1133,9 @@ RSpec.describe Puppet::ResourceApi do
       }
     end
 
-    it { expect { described_class.register_type(definition) }.not_to raise_error }
+    before(:each) do
+      described_class.register_type(definition)
+    end
 
     describe 'the registered type' do
       subject(:type) { Puppet::Type.type(:composite) }
@@ -1142,7 +1144,7 @@ RSpec.describe Puppet::ResourceApi do
       it { expect(type.parameters).to eq [:package, :manager] }
     end
 
-    describe 'an instance of the type' do
+    describe 'the type\'s class' do
       let(:provider_class) do
         Class.new do
           def get(_context)
@@ -1152,33 +1154,54 @@ RSpec.describe Puppet::ResourceApi do
           def set(_context, _changes); end
         end
       end
-      let(:instance) { Puppet::Type.type(:composite) }
+      let(:type_class) { Puppet::Type.type(:composite) }
 
       before(:each) do
         stub_const('Puppet::Provider::Composite', Module.new)
         stub_const('Puppet::Provider::Composite::Composite', provider_class)
       end
 
-      context 'when title_patterns called' do
+      describe '.title_patterns' do
         it 'returns correctly generated pattern' do
           # [[ %r{^(?<package>.*[^/])/(?<manager>.*)$},[[:package],[:manager]]],[%r{^(?<package>.*)$},[[:package]]]]
 
-          expect(instance.title_patterns.first[0]).to be_a Regexp
-          expect(instance.title_patterns.first[0]).to eq(%r{^(?<package>.*[^/])/(?<manager>.*)$})
-          expect(instance.title_patterns.first[1].size).to eq 2
-          expect(instance.title_patterns.first[1][0][0]).to eq :package
-          expect(instance.title_patterns.first[1][1][0]).to eq :manager
+          expect(type_class.title_patterns.first[0]).to be_a Regexp
+          expect(type_class.title_patterns.first[0]).to eq(%r{^(?<package>.*[^/])/(?<manager>.*)$})
+          expect(type_class.title_patterns.first[1].size).to eq 2
+          expect(type_class.title_patterns.first[1][0][0]).to eq :package
+          expect(type_class.title_patterns.first[1][1][0]).to eq :manager
 
-          expect(instance.title_patterns.last[0]).to be_a Regexp
-          expect(instance.title_patterns.last[0]).to eq(%r{^(?<package>.*)$})
-          expect(instance.title_patterns.last[1].size).to eq 1
-          expect(instance.title_patterns.last[1][0][0]).to eq :package
+          expect(type_class.title_patterns.last[0]).to be_a Regexp
+          expect(type_class.title_patterns.last[0]).to eq(%r{^(?<package>.*)$})
+          expect(type_class.title_patterns.last[1].size).to eq 1
+          expect(type_class.title_patterns.last[1][0][0]).to eq :package
         end
       end
 
-      context 'when instances called' do
+      describe '.instances' do
         it 'uses the title provided by the provider' do
-          expect(instance.instances[0].title).to eq('php/yum')
+          expect(type_class.instances[0].title).to eq('php/yum')
+        end
+      end
+
+      context 'when flushing an instance' do
+        let(:provider_instance) { instance_double(provider_class, 'provider_instance') }
+
+        before(:each) do
+          allow(provider_class).to receive(:new).and_return(provider_instance)
+        end
+
+        after(:each) do
+          # reset cached provider between tests
+          type_class.instance_variable_set(:@my_provider, nil)
+        end
+
+        it 'uses a hash as `name` when setting values' do
+          allow(provider_instance).to receive(:get).and_return([{ title: 'php/yum', package: 'php', manager: 'yum', ensure: 'present' }])
+          expect(provider_instance).to receive(:set) { |_context, changes|
+            expect(changes.keys).to eq [{ package: 'php', manager: 'yum' }]
+          }
+          type_class.new(title: 'php/yum', ensure: :absent).flush
         end
       end
     end


### PR DESCRIPTION
This is a series of changes to make the composite namevar behaviour work. See the individual commits for details and https://github.com/puppetlabs/puppet-specifications/pull/140 for the specification changes/clarifications.