### PR TITLE
(maint) make test order really random

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --format documentation
 --color
---order rand:123
+--order rand

--- a/spec/puppet/resource_api/type_definition_spec.rb
+++ b/spec/puppet/resource_api/type_definition_spec.rb
@@ -119,6 +119,10 @@ RSpec.describe Puppet::ResourceApi::TypeDefinition do
         Puppet.settings[:strict] = strict_level
       end
 
+      after(:each) do
+        Puppet::ResourceApi.warning_count = 0
+      end
+
       context 'when puppet strict is set to default (warning)' do
         it 'displays up to 100 warnings' do
           expect(Puppet).to receive(:warning).with(message).exactly(100).times
@@ -154,6 +158,10 @@ RSpec.describe Puppet::ResourceApi::TypeDefinition do
       before(:each) do
         Puppet::ResourceApi.warning_count = 0
         Puppet.settings[:strict] = strict_level
+      end
+
+      after(:each) do
+        Puppet::ResourceApi.warning_count = 0
       end
 
       context 'when puppet strict is set to default (warning)' do

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -1816,20 +1816,22 @@ CODE
 
     it { expect { described_class.register_type(definition) }.not_to raise_error }
 
-    it 'is seen as a supported feature' do
-      expect(Puppet).not_to receive(:warning).with(%r{Unknown feature detected:.*simple_test_filter})
-      expect { described_class.register_type(definition) }.not_to raise_error
-    end
+    context 'with the type registered' do
+      it 'is seen as a supported feature' do
+        expect(Puppet).not_to receive(:warning).with(%r{Unknown feature detected:.*simple_test_filter})
+        expect { described_class.register_type(definition) }.not_to raise_error
+      end
 
-    it 'passes through the an empty array to `get`' do
-      expect(provider).to receive(:get).with(anything, []).and_return([])
-      type.instances
-    end
+      it 'passes through the an empty array to `get`' do
+        expect(provider).to receive(:get).with(anything, []).and_return([])
+        type.instances
+      end
 
-    it 'passes through the resource title to `get`' do
-      instance = type.new(name: 'bar', ensure: 'present')
-      expect(provider).to receive(:get).with(anything, ['bar']).and_return([])
-      instance.retrieve
+      it 'passes through the resource title to `get`' do
+        instance = type.new(name: 'bar', ensure: 'present')
+        expect(provider).to receive(:get).with(anything, ['bar']).and_return([])
+        instance.retrieve
+      end
     end
   end
 

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -1814,6 +1814,11 @@ CODE
       allow(provider_class).to receive(:new).and_return(provider)
     end
 
+    after(:each) do
+      # reset cached provider between tests
+      type.instance_variable_set(:@my_provider, nil)
+    end
+
     it { expect { described_class.register_type(definition) }.not_to raise_error }
 
     context 'with the type registered' do


### PR DESCRIPTION
The test leakage fixed in #174 was only detected by
changing the test order. Removing the seed will ensure that different
test orderings are tested, leading to a more robust test suite as new
issues are discovered and fixed.

This already has found another issue fixed here too.