### PR TITLE
(maint) implement `desc`/`docs` fallback

### DIFF
--- a/spec/puppet/resource_api/base_context_spec.rb
+++ b/spec/puppet/resource_api/base_context_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Puppet::ResourceApi::BaseContext do
     TestContext.new(definition)
   end
 
-  let(:definition) { { name: 'some_resource', attributes: { name: 'some_resource' }, features: feature_support } }
+  let(:definition) { { name: 'some_resource', desc: 'a test resource', attributes: { name: { type: 'String', desc: 'message' } }, features: feature_support } }
   let(:feature_support) { [] }
 
   it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{BaseContext requires definition to be a Hash} }

--- a/spec/puppet/resource_api/puppet_context_spec.rb
+++ b/spec/puppet/resource_api/puppet_context_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Puppet::ResourceApi::PuppetContext do
   subject(:context) { described_class.new(definition) }
 
-  let(:definition) { { name: 'some_resource' } }
+  let(:definition) { { name: 'some_resource', desc: 'a test resource', attributes: {} } }
 
   describe '#device' do
     context 'when a NetworkDevice is configured' do


### PR DESCRIPTION
This implements the changes specified in https://github.com/puppetlabs/puppet-specifications/pull/141

> The text and examples have been inconsistent with how `desc` vs `docs`
> has been handled. This change fixes the text and examples to all show
> and require `desc`, but accept `docs` in places where we showed it
> previously.