### PR TITLE
(maint) Merge 1.6.x to master 

### DIFF
--- a/lib/puppet/resource_api/glue.rb
+++ b/lib/puppet/resource_api/glue.rb
@@ -48,6 +48,10 @@ module Puppet::ResourceApi
       resource.to_json
     end
 
+    def to_hash
+      values
+    end
+
     # attribute names that are not title or namevars
     def filtered_keys
       values.keys.reject { |k| k == :title || !attr_def[k] || (attr_def[k][:behaviour] == :namevar && @namevars.size == 1) }

--- a/spec/puppet/resource_api/glue_spec.rb
+++ b/spec/puppet/resource_api/glue_spec.rb
@@ -73,5 +73,9 @@ RSpec.describe 'the dirty bits' do
         it { expect(instance.to_hierayaml).to eq "  ? |-\n    foo:\n    bar\n  : attr: value\n    attr_ro: fixed\n" }
       end
     end
+
+    describe '.to_hash' do
+      it { expect(instance.to_hash).to eq(namevarname: 'title', attr: 'value', attr_ro: 'fixed') }
+    end
   end
 end


### PR DESCRIPTION
The only conflict was related to these two commits:
https://github.com/puppetlabs/puppet-resource_api/commit/83323bff2ee52d3d51730b5b3c3e846027299398
https://github.com/puppetlabs/puppet-resource_api/commit/be6d8dd56266e3a0236a216c6ee80a728fcc0214

First one implements "to_json" the second one implements "to_hash".

Based on the commit messages, I've made the assumption that both methods need to get into master.