### PR TITLE
(maint) backport minor fixes from master to 1.6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       cache:
         bundler: true
         directories: ~/.rvm
-      before_install: rvm use jruby-1.7.26 --install --binary --fuzzy
+      before_install: rvm use jruby-1.7.26 --install --binary --fuzzy && gem install bundler -v '~> 1.7.0'
     # disable coverage on jruby9k as this confuses codecov
     - env: RVM="jruby-9.1.9.0" PUPPET_GEM_VERSION='~> 5' JRUBY_OPTS="--debug"
       before_cache: pushd ~/.rvm && rm -rf archives rubies/ruby-2.2.7 rubies/ruby-2.3.4 && popd

--- a/Gemfile
+++ b/Gemfile
@@ -7,16 +7,14 @@ gemspec
 
 group :tests do
   gem 'codecov'
-  # license_finder does not install on windows using older versions of rubygems.
-  # ruby 2.4 is confirmed working on appveyor.
-  gem 'license_finder' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3.0'
   # rubocop 0.58 throws when testing against ruby 2.1, so pin to the latest,
   # unless we're dealing with jruby...
   if RUBY_PLATFORM == 'java'
-    # load any rubocop version that works on java for the Rakefile
-    gem 'rubocop'
+    # load a rubocop version that works on java for the Rakefile
+    gem 'parser', '2.3.3.1'
+    gem 'rubocop', '0.41.2'
   elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.0')
     gem 'rubocop', '0.57.2'
     # the last version of parallel to support ruby 2.1
@@ -27,6 +25,9 @@ group :tests do
     # This needs to be removed once we drop puppet4 support.
     gem 'rubocop', '~> 0.57.0'
     gem 'rubocop-rspec'
+    # license_finder does not install on windows using older versions of rubygems.
+    # ruby 2.4 is confirmed working on appveyor.
+    gem 'license_finder' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
   end
   gem 'simplecov-console'
   # the test gems required for module testing

--- a/lib/puppet/resource_api/glue.rb
+++ b/lib/puppet/resource_api/glue.rb
@@ -45,6 +45,13 @@ module Puppet::ResourceApi
       values
     end
 
+    def to_json(*)
+      attrs = filtered_keys.map { |k| [k.to_s, values[k]] unless values[k].nil? }
+      attributes = Hash[*attrs.compact.flatten]
+      resource = { title => attributes }
+      resource.to_json
+    end
+
     # attribute names that are not title or namevars
     def filtered_keys
       values.keys.reject { |k| k == :title || !attr_def[k] || (attr_def[k][:behaviour] == :namevar && @namevars.size == 1) }

--- a/spec/integration/resource_api_spec.rb
+++ b/spec/integration/resource_api_spec.rb
@@ -223,6 +223,10 @@ RSpec.describe 'Resource API integrated tests:' do
         describe 'its title' do
           it { expect(instance.to_resource.title).to eq 'somename' }
         end
+
+        it 'can serialize to json' do
+          expect({ 'resources' => [instance.to_resource] }.to_json).to eq '{"resources":[{"somename":{"ensure":"absent","boolean_param":false,"integer_param":99,"float_param":3.21,"ensure_param":"present","variant_pattern_param":"1234ABCD","url_param":"http://www.puppet.com","string_array_param":"d","e":"f","string_param":"default value"}}]}' # rubocop:disable Metrics/LineLength
+        end
       end
 
       it('ensure is reported as a symbol') { expect(instance[:ensure]).to be_a Symbol }

--- a/spec/puppet/resource_api/glue_spec.rb
+++ b/spec/puppet/resource_api/glue_spec.rb
@@ -47,6 +47,23 @@ RSpec.describe 'the dirty bits' do
       end
     end
 
+    describe '.to_json' do
+      it { expect(instance.to_json).to eq '{"title":{"attr":"value","attr_ro":"fixed"}}' }
+
+      context 'with nil values' do
+        subject(:instance) do
+          described_class.new({ namevarname: title, attr: nil, attr_ro: 'fixed' }, 'typename', [:namevarname],
+                              namevarname: { type: 'String', behaviour: :namevar, desc: 'the title' },
+                              attr: { type: 'String', desc: 'a string parameter' },
+                              attr_ro: { type: 'String', desc: 'a string readonly', behaviour: :read_only })
+        end
+
+        it 'doesn\'t output them' do
+          expect(instance.to_json).to eq '{"title":{"attr_ro":"fixed"}}'
+        end
+      end
+    end
+
     describe '.to_hierayaml' do
       it { expect(instance.to_hierayaml).to eq "  title:\n    attr: value\n    attr_ro: fixed\n" }
 


### PR DESCRIPTION
* (maint) Fixup Gemfile for JRuby 1.7 installs
  needed for running travis on 1.6.x changes
* (FM-7839) Implement 'to_json' method for ResourceShim for bolt
  required to support bolt


Both changes are cherry-picks from the master branch and both should have originally been applied to 1.6.x and merged up instead.