### PR TITLE
(maint) test fixes

### DIFF
--- a/spec/puppet/resource_api/transport_spec.rb
+++ b/spec/puppet/resource_api/transport_spec.rb
@@ -260,6 +260,10 @@ RSpec.describe Puppet::ResourceApi::Transport do
       end
     end
 
+    after(:each) do
+      Puppet::Util::NetworkDevice.instance_variable_set(:@current, nil)
+    end
+
     context 'when puppet has set_device' do
       it 'wraps the transport and calls set_device within NetworkDevice' do
         expect(Puppet::ResourceApi::Transport::Wrapper).to receive(:new).with(device_name, transport).and_return(wrapper)

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -1767,6 +1767,11 @@ CODE
       allow(provider_class).to receive(:new).and_return(provider)
     end
 
+    after(:each) do
+      # reset cached provider between tests
+      type.instance_variable_set(:@my_provider, nil)
+    end
+
     it { expect { described_class.register_type(definition) }.not_to raise_error }
 
     it 'is seen as a supported feature' do


### PR DESCRIPTION
These test fixes are fixes for unclean tests uncovered by `--rand` test ordering. 