### PR TITLE
(SERVER-2470) list_all_transports implementation for puppetserver

### DIFF
--- a/spec/integration/resource_api/transport_spec.rb
+++ b/spec/integration/resource_api/transport_spec.rb
@@ -1,13 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe 'Resource API Transport integration tests:' do
-  after(:each) do
-    # reset registered transports between tests to reduce cross-test poisoning
-    Puppet::ResourceApi::Transport.instance_variable_set(:@transports, nil)
-    autoloader = Puppet::ResourceApi::Transport.instance_variable_get(:@autoloader)
-    autoloader.class.loaded.clear
-  end
-
   describe '#list_all_transports' do
     subject(:transports) { Puppet::ResourceApi::Transport.list_all_transports('rp_env') }
 

--- a/spec/integration/resource_api/transport_spec.rb
+++ b/spec/integration/resource_api/transport_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe 'Resource API Transport integration tests:' do
+  after(:each) do
+    # reset registered transports between tests to reduce cross-test poisoning
+    Puppet::ResourceApi::Transport.instance_variable_set(:@transports, nil)
+    autoloader = Puppet::ResourceApi::Transport.instance_variable_get(:@autoloader)
+    autoloader.class.loaded.clear
+  end
+
+  describe '#list_all_transports' do
+    subject(:transports) { Puppet::ResourceApi::Transport.list_all_transports('rp_env') }
+
+    it 'can be called twice' do
+      expect {
+        Puppet::ResourceApi::Transport.list_all_transports('rp_env')
+        Puppet::ResourceApi::Transport.list_all_transports('rp_env')
+      }.not_to raise_error
+    end
+
+    it 'loads all transports' do
+      expect(transports).to have_key 'test_device'
+      expect(transports).to have_key 'test_device_sensitive'
+      expect(transports['test_device']).to be_a Puppet::ResourceApi::TransportSchemaDef
+      expect(transports['test_device'].definition).to include(name: 'test_device')
+    end
+  end
+end

--- a/spec/puppet/resource_api/transport_spec.rb
+++ b/spec/puppet/resource_api/transport_spec.rb
@@ -29,11 +29,6 @@ RSpec.describe Puppet::ResourceApi::Transport do
     Puppet.debug = true
   end
 
-  after(:each) do
-    # reset registered transports between tests to reduce cross-test poisoning
-    described_class.instance_variable_set(:@transports, nil)
-  end
-
   describe '#register(schema)' do
     context 'when registering a schema with missing keys' do
       it { expect { described_class.register([]) }.to raise_error(Puppet::DevError, %r{requires a hash as schema}) }

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -1847,7 +1847,7 @@ CODE
   context 'when loading a type with unknown features' do
     let(:definition) do
       {
-        name: 'test_noop_support',
+        name: 'test_noop_support_2',
         desc: 'a test resource',
         features: ['no such feature'],
         attributes: {},

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'bundler/setup'
+require 'rspec-puppet'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -13,6 +14,9 @@ RSpec.configure do |config|
 
   # override legacy default from puppetlabs_spec_helper
   config.mock_with :rspec
+
+  # enable rspec-puppet support everywhere
+  config.include RSpec::Puppet::Support
 
   # reset the warning suppression count
   config.before(:each) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,3 +30,14 @@ require 'puppet/resource_api'
 
 # exclude the `version.rb` which already gets loaded by bundler via the gemspec, and doesn't need coverage testing anyways.
 SimpleCov.add_filter 'lib/puppet/resource_api/version.rb' if ENV['SIMPLECOV'] == 'yes'
+
+# configure this hook after Resource API is loaded to get access to Puppet::ResourceApi::Transport
+RSpec.configure do |config|
+  config.after(:each) do
+    # reset registered transports between tests to reduce cross-test poisoning
+    Puppet::ResourceApi::Transport.instance_variable_set(:@transports, nil)
+    if (autoloader = Puppet::ResourceApi::Transport.instance_variable_get(:@autoloader))
+      autoloader.class.loaded.clear
+    end
+  end
+end


### PR DESCRIPTION
To test out, run `rake spec_prep` and use the following setup in pry:

```
require 'puppet'
require 'puppet/resource_api/transport'
require 'puppet/settings'

Puppet.initialize_settings
Puppet[:modulepath] = 'spec/fixtures/modules'

# env = Puppet.lookup(:environments).get!('production')
# files = Puppet::Util::Autoload.files_to_load('puppet/transport/schema', env)

Puppet::ResourceApi::Transport.list_all_transports('production')
```