### PR TITLE
(maint) Pin both Jruby cells to use `dist: trusty`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
     - rvm: 2.4.3
       env: PUPPET_GEM_VERSION='~> 5' SIMPLECOV=yes # 5.5
     - env: RVM="jruby-1.7.26" PUPPET_GEM_VERSION='~> 5' JRUBY_OPTS="--debug" SIMPLECOV=yes
+      dist: trusty
       before_cache: pushd ~/.rvm && rm -rf archives rubies/ruby-2.2.7 rubies/ruby-2.3.4 && popd
       cache:
         bundler: true
@@ -23,6 +24,7 @@ matrix:
       before_install: rvm use jruby-1.7.26 --install --binary --fuzzy && gem install bundler -v '~> 1.7.0'
     # disable coverage on jruby9k as this confuses codecov
     - env: RVM="jruby-9.1.9.0" PUPPET_GEM_VERSION='~> 5' JRUBY_OPTS="--debug"
+      dist: trusty
       before_cache: pushd ~/.rvm && rm -rf archives rubies/ruby-2.2.7 rubies/ruby-2.3.4 && popd
       cache:
         bundler: false


### PR DESCRIPTION
It appears that Travis have updated their default distro from `trusty` to `xenial`. This brought with it updates to the ruby and bundler versions used. Pinning back to `trusty` in the short term with a long term fix to investigate the compatibility between Jruby and the new `xenial` build environment.

