### PR TITLE
(packaging) Bump to version '1.9.0' [no-promote]

### DIFF
--- a/lib/puppet/resource_api/version.rb
+++ b/lib/puppet/resource_api/version.rb
@@ -1,5 +1,5 @@
 module Puppet
   module ResourceApi
-    VERSION = '1.8.8'.freeze
+    VERSION = '1.9.0'.freeze
   end
 end


### PR DESCRIPTION
The automatic bump script missed this since version 1.9.0 was previously committed/reverted in 1edc1b583655393d747ea0ac48f1718ddc4d8889