### PR TITLE
(FM-8553) Remove all caching from list_all_transports

### DIFF
--- a/spec/integration/resource_api/transport_spec.rb
+++ b/spec/integration/resource_api/transport_spec.rb
@@ -4,18 +4,19 @@ RSpec.describe 'Resource API Transport integration tests:' do
   describe '#list_all_transports' do
     subject(:transports) { Puppet::ResourceApi::Transport.list_all_transports('rp_env') }
 
-    it 'can be called twice' do
-      expect {
-        Puppet::ResourceApi::Transport.list_all_transports('rp_env')
-        Puppet::ResourceApi::Transport.list_all_transports('rp_env')
-      }.not_to raise_error
-    end
-
     it 'loads all transports' do
       expect(transports).to have_key 'test_device'
       expect(transports).to have_key 'test_device_sensitive'
       expect(transports['test_device']).to be_a Puppet::ResourceApi::TransportSchemaDef
       expect(transports['test_device'].definition).to include(name: 'test_device')
+    end
+
+    it 'can be called twice' do
+      expect(Puppet::ResourceApi::Transport.list).to be_empty
+      Puppet::ResourceApi::Transport.list_all_transports('rp_env')
+      expect(Puppet::ResourceApi::Transport.list.length).to eq 2
+      Puppet::ResourceApi::Transport.list_all_transports('rp_env')
+      expect(Puppet::ResourceApi::Transport.list.length).to eq 2
     end
   end
 end


### PR DESCRIPTION
It turned out that the environment object in the puppetserver does not survive for longer than a request, making the ObjectIdCacheAdapter creating a new cache everytime. Since the autoloader was using `require` to load schemas, this lead to the cache not being refresehd, and the API would return wrong (empty) results.

This change fixes this by not caching at all and using `load` instead of `require`, so that the schemas are always freshly loaded.