### PR TITLE
(FM-8336) Capture and expose attribute ordering from transport schema

### DIFF
--- a/lib/puppet/resource_api/transport.rb
+++ b/lib/puppet/resource_api/transport.rb
@@ -8,6 +8,11 @@ module Puppet::ResourceApi::Transport
     raise Puppet::DevError, 'requires `:desc`' unless schema.key? :desc
     raise Puppet::DevError, 'requires `:connection_info`' unless schema.key? :connection_info
     raise Puppet::DevError, '`:connection_info` must be a hash, not `%{other_type}`' % { other_type: schema[:connection_info].class } unless schema[:connection_info].is_a?(Hash)
+    if schema[:connection_info_order].nil?
+      schema[:connection_info_order] = schema[:connection_info].keys
+    else
+      raise Puppet::DevError, '`:connection_info_order` must be an array, not `%{other_type}`' % { other_type: schema[:connection_info_order].class } unless schema[:connection_info_order].is_a?(Array)
+    end
 
     unless transports[schema[:name]].nil?
       raise Puppet::DevError, 'Transport `%{name}` is already registered for `%{environment}`' % {

--- a/spec/integration/resource_api/transport_spec.rb
+++ b/spec/integration/resource_api/transport_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe 'Resource API Transport integration tests:' do
       expect(transports['test_device'].definition).to include(name: 'test_device')
     end
 
+    it 'adds connection_info_order' do
+      expect(transports['test_device'].definition).to include(connection_info_order: a_kind_of(Array))
+    end
+
     it 'can be called twice' do
       expect(Puppet::ResourceApi::Transport.list).to be_empty
       Puppet::ResourceApi::Transport.list_all_transports('rp_env')

--- a/spec/puppet/resource_api/transport_spec.rb
+++ b/spec/puppet/resource_api/transport_spec.rb
@@ -30,12 +30,36 @@ RSpec.describe Puppet::ResourceApi::Transport do
   end
 
   describe '#register(schema)' do
-    context 'when registering a schema with missing keys' do
+    describe 'validation checks' do
       it { expect { described_class.register([]) }.to raise_error(Puppet::DevError, %r{requires a hash as schema}) }
       it { expect { described_class.register({}) }.to raise_error(Puppet::DevError, %r{requires a `:name`}) }
       it { expect { described_class.register(name: 'no connection info', desc: 'some description') }.to raise_error(Puppet::DevError, %r{requires `:connection_info`}) }
       it { expect { described_class.register(name: 'no description') }.to raise_error(Puppet::DevError, %r{requires `:desc`}) }
-      it { expect { described_class.register(name: 'no hash attributes', desc: 'some description', connection_info: []) }.to raise_error(Puppet::DevError, %r{`:connection_info` must be a hash, not}) }
+      it {
+        expect {
+          described_class.register(name: 'no hash connection_info',
+                                   desc: 'some description',
+                                   connection_info: [])
+        } .to raise_error(Puppet::DevError, %r{`:connection_info` must be a hash, not})
+      }
+      it {
+        expect(described_class.register(name: 'no array connection_info_order',
+                                        desc: 'some description',
+                                        connection_info: {}).definition).to have_key(:connection_info_order)
+      }
+      it {
+        expect(described_class.register(name: 'no array connection_info_order',
+                                        desc: 'some description',
+                                        connection_info: {}).definition[:connection_info_order]).to eq []
+      }
+      it {
+        expect {
+          described_class.register(name: 'no array connection_info_order',
+                                   desc: 'some description',
+                                   connection_info: {},
+                                   connection_info_order: {})
+        }.to raise_error(Puppet::DevError, %r{`:connection_info_order` must be an array, not})
+      }
     end
 
     context 'when registering a minimal transport' do


### PR DESCRIPTION
When exposing attributes in the UI, they currently need to be alphabetised by their name, since the transmission through APIs does not preserve key order of the connection_info hash.

To facilitate showing attributes in the order defined by the module author, this change embeds the key-insertion order from the TypeDefinition into the API response.