### PR TITLE
Add title consistency checks for multi-namevar providers

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -355,7 +355,7 @@ module Puppet::ResourceApi
         return if Puppet.settings[:strict] == :off
 
         strict_check_canonicalize(current_state) if type_definition.feature?('canonicalize')
-        strict_check_title_parameter(current_state) if type_definition.namevars.size > 1
+        strict_check_title_parameter(current_state) if type_definition.namevars.size > 1 && !type_definition.title_patterns.empty?
 
         nil
       end

--- a/lib/puppet/resource_api/type_definition.rb
+++ b/lib/puppet/resource_api/type_definition.rb
@@ -18,6 +18,10 @@ module Puppet::ResourceApi
       (definition[:features] && definition[:features].include?(feature))
     end
 
+    def title_patterns
+      definition[:title_patterns] ||= []
+    end
+
     def validate_schema(definition, attr_key)
       super(definition, attr_key)
       [:title, :provider, :alias, :audit, :before, :consume, :export, :loglevel, :noop, :notify, :require, :schedule, :stage, :subscribe, :tag].each do |name|

--- a/spec/fixtures/test_module/lib/puppet/type/multiple_namevar.rb
+++ b/spec/fixtures/test_module/lib/puppet/type/multiple_namevar.rb
@@ -5,6 +5,16 @@ Puppet::ResourceApi.register_type(
   docs: <<-EOS,
     This type provides Puppet with the capabilities to manage ...
   EOS
+  title_patterns: [
+    {
+      pattern: %r{^(?<package>.*[^-])-(?<manager>.*)$},
+      desc: 'Package and manager with a hyphen seperator',
+    },
+    {
+      pattern: %r{^(?<package>.*)$},
+      desc: 'Package',
+    },
+  ],
   attributes:   {
     ensure:      {
       type:    'Enum[present, absent]',


### PR DESCRIPTION
This ensures that title values, if returned from a multi-namevar
provider, meet the following consistency checks:

* The title value must match one of the title patterns
* The values parsed from the title pattern match must match the
  values returned from the provider for the respective namevars.