### PR TITLE
Reset context.failed? between resources

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -331,7 +331,10 @@ module Puppet::ResourceApi
         else
           my_provider.set(context, rsapi_title => { is: @rsapi_current_state, should: target_state }) unless noop?
         end
-        raise 'Execution encountered an error' if context.failed?
+        if context.failed?
+          context.reset_failed
+          raise 'Execution encountered an error'
+        end
 
         # remember that we have successfully reached our desired state
         @rsapi_current_state = target_state

--- a/lib/puppet/resource_api/base_context.rb
+++ b/lib/puppet/resource_api/base_context.rb
@@ -33,6 +33,10 @@ class Puppet::ResourceApi::BaseContext
     @failed
   end
 
+  def reset_failed
+    @failed = false
+  end
+
   def feature_support?(feature)
     Puppet.deprecation_warning('context.feature_support? is deprecated. Please use context.type.feature? instead.')
     type.feature?(feature)

--- a/spec/acceptance/failure_spec.rb
+++ b/spec/acceptance/failure_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'tempfile'
+
+RSpec.describe 'a provider showing failure' do
+  let(:common_args) { '--verbose --trace --strict=error --modulepath spec/fixtures --detailed-exitcodes' }
+
+  describe 'using `puppet apply`' do
+    let(:result) { Open3.capture2e("puppet apply #{common_args} -e \"#{manifest.delete("\n").squeeze(' ')}\"") }
+    let(:stdout_str) { result[0] }
+    let(:status) { result[1] }
+
+    context 'when changes are made' do
+      let(:manifest) do
+        <<DOC
+        test_failure {
+          one:   failure=>false;
+          two:   failure=>true;
+          three: failure=>false;
+        }
+DOC
+      end
+
+      it 'applies a catalog with some failing resources' do
+        expect(stdout_str).to match %r{Creating 'one' with \{:name=>"one", :failure=>false, :ensure=>"present"\}}
+        expect(stdout_str).to match %r{Creating 'two' with \{:name=>"two", :failure=>true, :ensure=>"present"\}}
+        expect(stdout_str).to match %r{Creating: Failed.*A failure for two}
+        expect(stdout_str).to match %r{Could not evaluate: Execution encountered an error}
+        expect(stdout_str).to match %r{Creating 'three' with \{:name=>"three", :failure=>false, :ensure=>"present"\}}
+        expect(stdout_str).not_to match %r{Creating: Failed.*A failure for three}
+        expect(stdout_str).to match %r{test_failure\[three\]: Finished}
+        expect(status.exitstatus).to eq 6
+      end
+    end
+  end
+end

--- a/spec/fixtures/test_module/lib/puppet/provider/test_failure/test_failure.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/test_failure/test_failure.rb
@@ -1,0 +1,24 @@
+require 'puppet/resource_api'
+require 'puppet/resource_api/simple_provider'
+
+# Implementation for the test_bool type using the Resource API.
+class Puppet::Provider::TestFailure::TestFailure
+  def get(_context)
+    []
+  end
+
+  def set(context, changes)
+    changes.each do |name, change|
+      is = change[:is]
+      should = change[:should]
+
+      context.notice(name, "Creating '#{name}' with #{should.inspect}")
+      if should[:failure]
+        context.creating(name) do
+          raise "A failure for #{name}"
+        end
+      end
+      context.notice(name, "Finished")
+    end
+  end
+end

--- a/spec/fixtures/test_module/lib/puppet/type/test_failure.rb
+++ b/spec/fixtures/test_module/lib/puppet/type/test_failure.rb
@@ -1,0 +1,26 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'test_failure',
+  docs: <<-DOC,
+      This type provides Puppet with the capabilities to manage ...
+  DOC
+  features: [],
+  attributes:   {
+    ensure:      {
+      type:    'Enum[present, absent]',
+      desc:    'Whether this resource should be present or absent on the target system.',
+      default: 'present',
+    },
+    name:        {
+      type:      'String',
+      desc:      'The name of the resource you want to manage.',
+      behaviour: :namevar,
+    },
+    failure:   {
+      type:      'Boolean',
+      desc:      'A boolean property for testing.',
+      default:   false,
+    },
+  },
+)

--- a/spec/puppet/resource_api/base_context_spec.rb
+++ b/spec/puppet/resource_api/base_context_spec.rb
@@ -364,4 +364,13 @@ RSpec.describe Puppet::ResourceApi::BaseContext do
       context.feature_support?('anything')
     }
   end
+
+  describe '#reset_failed' do
+    it 'resets the failure state' do
+      context.failing('bad_resource') { raise StandardError, 'Bad Resource!' }
+      expect(context).to be_failed
+      context.reset_failed
+      expect(context).not_to be_failed
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'rspec-puppet'
+require 'open3'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Ensure that context.failed? is reset after a failure encountered
during a flush so following resources do not falsely indicate
they encountered an error.