### PR TITLE
Update dependency_decisions for LicenseFinder 6.0; Fix deprecation warning with outdated win32-service gem pulled in by puppet

### DIFF
--- a/.dependency_decisions.yml
+++ b/.dependency_decisions.yml
@@ -1,41 +1,41 @@
 ---
-- - :whitelist
+- - :permit
   - MIT
   - :who: DavidS
     :why: standard license
     :versions: []
     :when: 2017-07-28 11:11:09.971500380 Z
-- - :whitelist
+- - :permit
   - Apache 2.0
   - :who: DavidS
     :why: standard license
     :versions: []
     :when: 2017-07-28 11:12:21.086779416 Z
-- - :whitelist
+- - :permit
   - ruby
   - :who: DavidS
     :why: standard license
     :versions: []
     :when: 2017-07-28 11:12:28.578927478 Z
-- - :whitelist
+- - :permit
   - Simplified BSD
   - :who: DavidS
     :why: standard license
     :versions: []
     :when: 2017-07-28 11:12:36.924605442 Z
-- - :whitelist
+- - :permit
   - New BSD
   - :who: DavidS
     :why: standard license
     :versions: []
     :when: 2017-07-28 11:14:00.252514982 Z
-- - :whitelist
+- - :permit
   - Apache License, v2
   - :who: DavidS
     :why: standard license
     :versions: []
     :when: 2017-07-28 11:14:07.999759997 Z
-- - :whitelist
+- - :permit
   - Ruby or LGPLv3+
   - :who: DavidS
     :why: standard license
@@ -62,7 +62,7 @@
     :why: https://github.com/defunkt/colored/blob/829bde0f8832406be1cacc5c99c49d976e05ccfc/LICENSE
     :versions: []
     :when: 2017-07-28 11:23:25.554994001 Z
-- - :whitelist
+- - :permit
   - ISC
   - :who: scotje
     :why: MIT equivalent
@@ -93,6 +93,6 @@
   - puppetlabs_spec_helper
   - Apache 2.0
   - :who: DavidS
-    :why: 
+    :why:
     :versions: []
     :when: 2018-03-09 18:04:29.175843919 Z

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+os: linux
 language: ruby
 bundler_args: "--without development"
 script:
@@ -10,8 +10,8 @@ script:
 cache: bundler
 branches:
   except:
-  - release-prep
-matrix:
+    - release-prep
+jobs:
   include:
     - rvm: 2.4.3
       env: PUPPET_GEM_VERSION='~> 5' SIMPLECOV=yes # 5.5
@@ -20,7 +20,7 @@ matrix:
       before_cache: pushd ~/.rvm && rm -rf archives rubies/ruby-2.2.7 rubies/ruby-2.3.4 && popd
       cache:
         bundler: true
-        directories: ~/.rvm
+        directories: [~/.rvm]
       before_install: rvm use jruby-1.7.26 --install --binary --fuzzy && gem install bundler -v '~> 1.7.0'
     # disable coverage on jruby9k as this confuses codecov
     - env: RVM="jruby-9.1.9.0" PUPPET_GEM_VERSION='~> 5' JRUBY_OPTS="--debug"
@@ -28,7 +28,7 @@ matrix:
       before_cache: pushd ~/.rvm && rm -rf archives rubies/ruby-2.2.7 rubies/ruby-2.3.4 && popd
       cache:
         bundler: false
-        directories: ~/.rvm
+        directories: [~/.rvm]
       before_install: rvm use jruby-9.1.9.0 --install --binary --fuzzy
     - rvm: 2.5.1
       env: CHECK=rubocop

--- a/spec/acceptance/device_spec.rb
+++ b/spec/acceptance/device_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe 'exercising a device provider' do
       it 'reads resources from the target system' do
         stdout_str, status = Open3.capture2e("puppet resource #{common_args} device_provider")
         expected_values = 'device_provider { \'wibble\': \n\s+ensure => \'present\',\n\s+string => \'sample\',\n\#\s+string_ro => \'fixed\', # Read Only\n  string_param => \'default value\',\n}'
-        expect(stdout_str.strip).to match %r{\A(DL is deprecated, please use Fiddle\n)?#{expected_values}\Z}
+        fiddle_deprecate_msg = "DL is deprecated, please use Fiddle\n"
+        win32_deprecate_msg = ".*Struct layout is already defined for class Windows::ServiceStructs::SERVICE_STATUS_PROCESS.*\n"
+        expect(stdout_str.strip).to match %r{\A(#{fiddle_deprecate_msg}|#{win32_deprecate_msg})?#{expected_values}\Z}
         expect(status).to eq 0
       end
 


### PR DESCRIPTION
See https://github.com/pivotal/LicenseFinder/issues/665 for reference