### PR TITLE
add Ruby 2.6.5 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ jobs:
       env: PUPPET_GEM_VERSION='~> 6' # 6.0, soon 6.1
     - rvm: 2.5.1
       env: PUPPET_GEM_VERSION='~> 6.0'
+    - rvm: 2.6.5
+      env: PUPPET_GEM_VERSION='~> 6.0'
     - rvm: 2.5.1
       env: PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#master'
     - rvm: 2.5.1


### PR DESCRIPTION
Ruby 2.6 was released over a year ago so I think it makes sense to test against it.