### PR TITLE
Add Ruby 2.7.0 to Travis-CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ jobs:
       env: PUPPET_GEM_VERSION='~> 6' # 6.0, soon 6.1
     - rvm: 2.5.1
       env: PUPPET_GEM_VERSION='~> 6.0'
+    - rvm: 2.7.0
+      env: PUPPET_GEM_VERSION='~> 6.0'
     - rvm: 2.5.1
       env: PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#master'
     - rvm: 2.5.1


### PR DESCRIPTION
Ruby 2.7 was released some time ago and the first distributions start to
ship it. Based on that I think it's a good idea to also run tests
against it.