### PR TITLE
Add `puppet` as runtime dependency

### DIFF
--- a/puppet-resource_api.gemspec
+++ b/puppet-resource_api.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'hocon', '>= 1.0'
+  spec.add_runtime_dependency 'puppet', '>= 4.0'
 end


### PR DESCRIPTION
several classes from the puppet gem are loaded within this lib, so it's
a runtime dependency.

This only specifies the absolute lowest bound that is required to make
the code load. Actual requirements, bug-for-bug compatibility and
commercial support options are a lot more complex than can be expressed
here.

Signed-off-by: David Schmitt <david.schmitt@puppet.com>