### PR TITLE
(maint) test handling of untyped and single-element arrays

### DIFF
--- a/spec/acceptance/array_spec.rb
+++ b/spec/acceptance/array_spec.rb
@@ -5,12 +5,28 @@ RSpec.describe 'a provider using arrays' do
   let(:common_args) { '--verbose --trace --strict=error --modulepath spec/fixtures' }
 
   describe 'using `puppet apply`' do
-    it 'applies a catalog successfully' do
-      # rubocop:disable Metrics/LineLength
-      stdout_str, _status = Open3.capture2e("puppet apply #{common_args} -e \"test_array { foo: some_array => [a, c, b], variant_array => 'not_an_array', array_of_arrays => [[a, b, c], [d, e, f]], array_from_hell => [a, [b, c], d] }\"")
-      expect(stdout_str).to match %r{Updating 'foo' with \{:name=>"foo", :some_array=>\["a", "c", "b"\], :variant_array=>"not_an_array", :array_of_arrays=>\[\["a", "b", "c"\], \["d", "e", "f"\]\], :array_from_hell=>\["a", \["b", "c"\], "d"\], :ensure=>"present"\}}
-      expect(stdout_str).not_to match %r{Error:}
-      # rubocop:enable Metrics/LineLength
+    context 'with multiple elements in an array' do
+      it 'applies a catalog successfully' do
+        # rubocop:disable Metrics/LineLength
+        stdout_str, _status = Open3.capture2e("puppet apply #{common_args} -e \"test_array { foo: some_array => [a, c, b], variant_array => 'not_an_array', array_of_arrays => [[a, b, c], [d, e, f]], array_from_hell => [a, [b, c], d], untyped => [e, f, g] }\"")
+        expect(stdout_str).to match %r{some_array changed \['a', 'b', 'c'\] to \['a', 'c', 'b'\]}
+        expect(stdout_str).to match %r{untyped changed \['e', 'f'\] to \['e', 'f', 'g'\]}
+        expect(stdout_str).to match %r{Updating 'foo' with \{:name=>"foo", :some_array=>\["a", "c", "b"\], :variant_array=>"not_an_array", :array_of_arrays=>\[\["a", "b", "c"\], \["d", "e", "f"\]\], :array_from_hell=>\["a", \["b", "c"\], "d"\], :untyped=>\["e", "f", "g"\], :ensure=>"present"\}}
+        expect(stdout_str).not_to match %r{Error:}
+        # rubocop:enable Metrics/LineLength
+      end
+    end
+
+    context 'with single elements in an array' do
+      it 'applies a catalog successfully' do
+        # rubocop:disable Metrics/LineLength
+        stdout_str, _status = Open3.capture2e("puppet apply #{common_args} -e \"test_array { foo: some_array => [a], variant_array => 'not_an_array', array_of_arrays => [[a, b, c]], array_from_hell => [[a]], untyped => [e] }\"")
+        expect(stdout_str).to match %r{some_array changed \['a', 'b', 'c'\] to \['a'\]}
+        expect(stdout_str).to match %r{untyped changed \['e', 'f'\] to \['e'\]}
+        expect(stdout_str).to match %r{Updating 'foo' with \{:name=>"foo", :some_array=>\["a"\], :variant_array=>"not_an_array", :array_of_arrays=>\[\["a", "b", "c"\]\], :array_from_hell=>\[\["a"\]\], :untyped=>\["e"\], :ensure=>"present"\}}
+        expect(stdout_str).not_to match %r{Error:}
+        # rubocop:enable Metrics/LineLength
+      end
     end
   end
 end

--- a/spec/fixtures/test_module/lib/puppet/provider/test_array/test_array.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/test_array/test_array.rb
@@ -9,6 +9,7 @@ class Puppet::Provider::TestArray::TestArray < Puppet::ResourceApi::SimpleProvid
         name: 'foo',
         ensure: 'present',
         some_array: %w[a b c],
+        untyped: %w[e f],
       },
       {
         name: 'bar',

--- a/spec/fixtures/test_module/lib/puppet/type/test_array.rb
+++ b/spec/fixtures/test_module/lib/puppet/type/test_array.rb
@@ -37,5 +37,9 @@ Puppet::ResourceApi.register_type(
       type: 'Optional[Array[String]]',
       desc: 'An optional attribute to exercise Array handling.',
     },
+    untyped: {
+      type: 'Optional[Any]',
+      desc: 'Testing array handling in `Any` typed properties.',
+    },
   },
 )

--- a/spec/integration/resource_api_spec.rb
+++ b/spec/integration/resource_api_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe 'Resource API integrated tests:' do
                  array_from_hell: ['a', %w[subb subc], 'd'],
                  boolean_param: false, integer_param: 99, float_param: 3.21, ensure_param: 'present',
                  variant_pattern_param: '1234ABCD', url_param:  'http://www.puppet.com',
-                 string_array_param: %w[d e f], alias: 'bar', audit: 'all', loglevel: 'crit', noop: false,
+                 string_array_param: ['d'], alias: 'bar', audit: 'all', loglevel: 'crit', noop: false,
                  tag: %w[a b c], catalog: catalog)
       end
 
@@ -251,7 +251,7 @@ RSpec.describe 'Resource API integrated tests:' do
         end
 
         it 'can serialize to json' do
-          expect({ 'resources' => [instance.to_resource] }.to_json).to eq '{"resources":[{"somename":{"name":"somename","name2":"othername","ensure":"absent","boolean_param":false,"integer_param":99,"float_param":3.21,"ensure_param":"present","variant_pattern_param":"1234ABCD","url_param":"http://www.puppet.com","string_array_param":"d","e":"f","string_param":"default value"}}]}' # rubocop:disable Metrics/LineLength
+          expect({ 'resources' => [instance.to_resource] }.to_json).to eq '{"resources":[{"somename":{"name":"somename","name2":"othername","ensure":"absent","boolean_param":false,"integer_param":99,"float_param":3.21,"ensure_param":"present","variant_pattern_param":"1234ABCD","url_param":"http://www.puppet.com","string_array_param":"d","string_param":"default value"}}]}' # rubocop:disable Metrics/LineLength
         end
       end
 


### PR DESCRIPTION
This is in response to PUP-10428. The tests are reproducing the conditions
reported.

The integration test does show the mishandling of array values (rsapi is
not using `array_matching`). The acceptance tests do show correct messages and changes
being effected despite this for arrays with multiple and single elements,
using the Array type and not using it.

While I do not fully understand (due to limited time for analysis) what
resource api is doing differently to not trigger the issue reported, the
fact that the enhanced acceptance tests are passing gives me confidence
to pass on further investigative work here.