### PR TITLE
Support `puppet device --resource ... --to_yaml` invocation; drop puppet4 and jruby 1.7 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,6 @@ jobs:
   include:
     - rvm: 2.4.3
       env: PUPPET_GEM_VERSION='~> 5' SIMPLECOV=yes # 5.5
-    - env: RVM="jruby-1.7.26" PUPPET_GEM_VERSION='~> 5' JRUBY_OPTS="--debug" SIMPLECOV=yes
-      dist: trusty
-      before_cache: pushd ~/.rvm && rm -rf archives rubies/ruby-2.2.7 rubies/ruby-2.3.4 && popd
-      cache:
-        bundler: true
-        directories: [~/.rvm]
-      before_install: rvm use jruby-1.7.26 --install --binary --fuzzy && gem install bundler -v '~> 1.7.0'
     # disable coverage on jruby9k as this confuses codecov
     - env: RVM="jruby-9.1.9.0" PUPPET_GEM_VERSION='~> 5' JRUBY_OPTS="--debug"
       dist: trusty
@@ -35,10 +28,6 @@ jobs:
     - rvm: 2.5.1
       env: CHECK=license_finder
       bundler_args: ""
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION='~> 4'  SIMPLECOV=yes # 4.10
-      before_install:
-        - gem install bundler -v '< 2'
     - rvm: 2.5.7
       env: PUPPET_GEM_VERSION='~> 6' SIMPLECOV=yes # latest 6 release
     - rvm: 2.5.7
@@ -47,8 +36,6 @@ jobs:
       env: PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#master'
     - rvm: 2.4.3
       env: PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#5.5.x'
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#4.10.x'
 notifications:
   slack:
     secure: aPXZYNow8LsmmlS8PQU3FjL0bc7FqUUA95d++wZfIu7YAjGboIUiekxYouQ0XnY+Aig8InvbTOIgBHgGNheyr/YFbFS90/jtulbF8oW7BitW+imgjeAHDCwlQZTCc4FFYde/2pI7QTT8H5NpLR9mKxlTU77Sqr8gFAIybuPdHcKMYQZdEZS07ma2pUp7+GyKS6PDQpzW2+mDCz/wfi3/JdsUvc0mclCZ8vxySc66j5P1E6nFDMzuakBOjwJHpgeDpreapbmSUQLAX0a3ZsFP+N+SNduLotlV2BWnJK2gcO6rGFP4Fz1D0bGXuBnYYdIiB+9OgI3wtXg9y1SifNHUG3IrOBAA8CGNyrebTGKtH0TS2O+HZLbaNX2g6udD5e3156vys9wScmJuQ/rSkVtQfXf1qUm5eijvlXI+DIbssbZHqm6QQGyM4p3NoULmNmF1C85bQoZ4GF7b1P/8mstsVE/HUfnzRPNbwD0r6j1aE/ck3PKMi7ZAhIi0Ja9RnAgP3wi0t62uERYcJGGYEycWohMWnrf2w6GFwGeuoiwAkASdHOLX0/AOMPc4mBOjlc621o8uYMrrZqfF5CrOAvJ151USSsWn2AhXaibIvnHo6X91paNvvNpU/GYu3CUAl6q8OhYovvjtRVPVnhs2DrpgoRB+6NWHnzjRG/wr6Z9U+vA=

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@ environment:
     - RUBY_VERSION: 25-x64
     - PUPPET_GEM_VERSION: '~> 5.0'
       RUBY_VERSION: 24-x64
-    - PUPPET_GEM_VERSION: '~> 4.0'
-      RUBY_VERSION: 21-x64
 
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%

--- a/lib/puppet/resource_api/glue.rb
+++ b/lib/puppet/resource_api/glue.rb
@@ -35,6 +35,10 @@ module Puppet::ResourceApi
       end + ['}']).compact.join("\n")
     end
 
+    def to_hiera_hash
+      to_hierayaml
+    end
+
     # Convert our resource to yaml for Hiera purposes.
     def to_hierayaml
       attributes = Hash[filtered_keys.map { |k| [k.to_s, values[k]] }]

--- a/lib/puppet/resource_api/glue.rb
+++ b/lib/puppet/resource_api/glue.rb
@@ -35,6 +35,7 @@ module Puppet::ResourceApi
       end + ['}']).compact.join("\n")
     end
 
+    # Required to enable `puppet device --resource ... --to_yaml` workflow
     def to_hiera_hash
       to_hierayaml
     end

--- a/spec/acceptance/device_spec.rb
+++ b/spec/acceptance/device_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe 'exercising a device provider' do
         expect(status).to eq 0
       end
 
+      it 'outputs resources as yaml' do
+        stdout_str, status = Open3.capture2e("puppet resource #{common_args} device_provider --to_yaml")
+        expected_values = "device_provider: |2\n\s+wibble:\n\s+ensure: :present\n\s+string: sample\n\s+string_ro: fixed\n\s+string_param: default value\n"
+        expect(stdout_str.strip).to match %r{#{expected_values}\Z}
+        expect(status).to eq 0
+      end
+
       it 'deals with canonicalized resources correctly' do
         stdout_str, status = Open3.capture2e("puppet resource #{common_args} device_provider wibble ensure=present #{default_type_values}")
         stdmatch = 'Notice: /Device_provider\[wibble\]/string: string changed \'sample\' to \'changed\''

--- a/spec/acceptance/device_spec.rb
+++ b/spec/acceptance/device_spec.rb
@@ -65,8 +65,10 @@ RSpec.describe 'exercising a device provider' do
 
       it 'outputs resources as yaml' do
         stdout_str, status = Open3.capture2e("puppet resource #{common_args} device_provider --to_yaml")
-        expected_values = "device_provider: |2\n\s+wibble:\n\s+ensure: :present\n\s+string: sample\n\s+string_ro: fixed\n\s+string_param: default value\n"
-        expect(stdout_str.strip).to match %r{#{expected_values}\Z}
+        expected_values = 'device_provider: |2\n\s+wibble:\n\s+ensure: :present\n\s+string: sample\n\s+string_ro: fixed\n\s+string_param: default value'
+        fiddle_deprecate_msg = "DL is deprecated, please use Fiddle\n"
+        win32_deprecate_msg = ".*Struct layout is already defined for class Windows::ServiceStructs::SERVICE_STATUS_PROCESS.*\n"
+        expect(stdout_str.strip).to match %r{\A(#{fiddle_deprecate_msg}|#{win32_deprecate_msg})?#{expected_values}\Z}
         expect(status).to eq 0
       end
 

--- a/spec/puppet/resource_api/glue_spec.rb
+++ b/spec/puppet/resource_api/glue_spec.rb
@@ -74,6 +74,16 @@ RSpec.describe 'the dirty bits' do
       end
     end
 
+    describe '.to_hiera_hash' do
+      it { expect(instance.to_hiera_hash).to eq "  title:\n    attr: value\n    attr_ro: fixed\n" }
+
+      context 'when the title contains YAML special characters' do
+        let(:title) { "foo:\nbar" }
+
+        it { expect(instance.to_hiera_hash).to eq "  ? |-\n    foo:\n    bar\n  : attr: value\n    attr_ro: fixed\n" }
+      end
+    end
+
     describe '.to_hash' do
       it { expect(instance.to_hash).to eq(namevarname: 'title', attr: 'value', attr_ro: 'fixed') }
     end


### PR DESCRIPTION
 - add `to_hiera_hash` method (invoking existing to_hierayaml)
 - add acceptance test running `puppet device --resource --to_yaml`
- remove testing on puppet4 and jruby 1.7: those versions have been out of support for a while now and upkeep of the tests is becoming a burden