### PR TITLE
This PR adds the type checker error message to validation output

### DIFF
--- a/lib/puppet/resource_api/type_definition.rb
+++ b/lib/puppet/resource_api/type_definition.rb
@@ -194,7 +194,7 @@ module Puppet::ResourceApi
         if is_sensitive
           bad_vals[key] = '<< redacted value >> ' + error_message unless error_message.nil?
         else
-          bad_vals[key] = value unless error_message.nil?
+          bad_vals[key] = "#{value} #{error_message}" unless error_message.nil?
         end
       end
       bad_vals

--- a/lib/puppet/resource_api/type_definition.rb
+++ b/lib/puppet/resource_api/type_definition.rb
@@ -194,7 +194,7 @@ module Puppet::ResourceApi
         if is_sensitive
           bad_vals[key] = '<< redacted value >> ' + error_message unless error_message.nil?
         else
-          bad_vals[key] = "#{value} #{error_message}" unless error_message.nil?
+          bad_vals[key] = "#{value} (#{error_message})" unless error_message.nil?
         end
       end
       bad_vals

--- a/spec/puppet/resource_api/base_type_definition_spec.rb
+++ b/spec/puppet/resource_api/base_type_definition_spec.rb
@@ -69,8 +69,11 @@ RSpec.describe Puppet::ResourceApi::BaseTypeDefinition do
       context 'when resource contains invalid values' do
         let(:resource) { { name: 'test_string', prop: 'foo', ensure: 1 } }
 
-        it 'returns a hash of the keys that have invalid values' do
-          expect(type.check_schema_values(resource)).to eq(prop: 'foo', ensure: 1)
+        it 'returns a hash of the keys that have invalid values and error messages' do
+          expect(type.check_schema_values(resource)).to eq(
+            prop: 'foo (expects an Integer value, got String)',
+            ensure: "1 (expects a match for Enum['absent', 'present'], got Integer)",
+          )
         end
       end
     end


### PR DESCRIPTION
The method `TypeDefinition#check_schema_values` now includes type checker error messages along with the values which failed validation thereby improving the UX.