### PR TITLE
Enable catalog access feature

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -430,7 +430,7 @@ MESSAGE
       end
 
       def context
-        @context ||= PuppetContext.new(TypeDefinition.new(definition), type_definition.feature?('raw_catalog_access') ? @catalog : nil)
+        @context ||= PuppetContext.new(type_definition, type_definition.feature?('raw_catalog_access') ? @catalog : nil)
       end
 
       def self.title_patterns

--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -430,8 +430,7 @@ MESSAGE
       end
 
       def context
-        self.class.context.catalog = @catalog if type_definition.feature?('raw_catalog_access')
-        self.class.context
+        @context ||= PuppetContext.new(TypeDefinition.new(definition), type_definition.feature?('raw_catalog_access') ? @catalog : nil)
       end
 
       def self.title_patterns

--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -430,6 +430,7 @@ MESSAGE
       end
 
       def context
+        self.class.context.catalog = @catalog if type_definition.feature?('raw_catalog_access')
         self.class.context
       end
 

--- a/lib/puppet/resource_api/base_context.rb
+++ b/lib/puppet/resource_api/base_context.rb
@@ -11,7 +11,7 @@ class Puppet::ResourceApi::BaseContext
   attr_reader :type
   attr_reader :catalog
 
-  def initialize(definition)
+  def initialize(definition, catalog = nil)
     if definition.is_a?(Hash)
       # this is only for backwards compatibility
       @type = Puppet::ResourceApi::TypeDefinition.new(definition)
@@ -20,6 +20,7 @@ class Puppet::ResourceApi::BaseContext
     else
       raise ArgumentError, 'BaseContext requires definition to be a child of Puppet::ResourceApi::BaseTypeDefinition, not <%{actual_type}>' % { actual_type: definition.class }
     end
+    @catalog = catalog
   end
 
   def device

--- a/lib/puppet/resource_api/base_context.rb
+++ b/lib/puppet/resource_api/base_context.rb
@@ -9,6 +9,7 @@ module Puppet::ResourceApi; end
 # The runtime environment will inject an appropriate implementation.
 class Puppet::ResourceApi::BaseContext
   attr_reader :type
+  attr_accessor :catalog
 
   def initialize(definition)
     if definition.is_a?(Hash)

--- a/lib/puppet/resource_api/base_context.rb
+++ b/lib/puppet/resource_api/base_context.rb
@@ -9,7 +9,7 @@ module Puppet::ResourceApi; end
 # The runtime environment will inject an appropriate implementation.
 class Puppet::ResourceApi::BaseContext
   attr_reader :type
-  attr_accessor :catalog
+  attr_reader :catalog
 
   def initialize(definition)
     if definition.is_a?(Hash)

--- a/lib/puppet/resource_api/type_definition.rb
+++ b/lib/puppet/resource_api/type_definition.rb
@@ -34,7 +34,7 @@ module Puppet::ResourceApi
       Puppet::ResourceApi::DataTypeHandling.validate_ensure(definition)
 
       definition[:features] ||= []
-      supported_features = %w[supports_noop canonicalize remote_resource simple_get_filter].freeze
+      supported_features = %w[supports_noop canonicalize remote_resource simple_get_filter raw_catalog_access].freeze
       unknown_features = definition[:features] - supported_features
       Puppet.warning("Unknown feature detected: #{unknown_features.inspect}") unless unknown_features.empty?
     end


### PR DESCRIPTION
This PR enables setting a `raw_catalog_access` feature flag on the type, which then provides access to the catalog in the provider by using `context.catalog`.