### PR TITLE
(GH-225) Add support for custom insync

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 ---
 require: rubocop-rspec
 AllCops:
-  TargetRubyVersion: '2.1'
+  TargetRubyVersion: '2.5'
   Include:
   - "**/*.rb"
   Exclude:

--- a/contrib/pre-commit
+++ b/contrib/pre-commit
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 # Code modified from: https://gist.github.com/hanloong/9849098
 require 'English'
 

--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'puppet/resource_api/data_type_handling'
 require 'puppet/resource_api/glue'

--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -123,6 +123,22 @@ module Puppet::ResourceApi
         @rsapi_title
       end
 
+      def rsapi_canonicalized_target_state
+        @rsapi_canonicalized_target_state ||= begin
+          # skip puppet's injected metaparams
+          actual_params = @parameters.select { |k, _v| type_definition.attributes.key? k }
+          target_state = Hash[actual_params.map { |k, v| [k, v.rs_value] }]
+          target_state = my_provider.canonicalize(context, [target_state]).first if type_definition.feature?('canonicalize')
+          target_state
+        end
+        @rsapi_canonicalized_target_state
+      end
+
+      def rsapi_current_state
+        refresh_current_state unless @rsapi_current_state
+        @rsapi_current_state
+      end
+
       def to_resource
         to_resource_shim(super)
       end
@@ -166,6 +182,21 @@ module Puppet::ResourceApi
         raise_missing_params if @missing_params.any?
       end
 
+      # If the custom_insync feature is specified but no insyncable attributes are included
+      # in the definition, add the hidden rsapi_custom_insync_trigger property.
+      # This property exists *only* to allow a resource without properties to still execute an
+      # insync check; there's no point in specifying it in a manifest as it can only have one
+      # value; it cannot be specified in a type definition as it should only exist in this case.
+      if type_definition.feature?('custom_insync') && type_definition.insyncable_attributes.empty?
+        custom_insync_trigger_options = {
+          type: 'Enum[do_not_specify_in_manifest]',
+          desc: 'A hidden property which enables a type with custom insync to perform an insync check without specifying any insyncable properties',
+          default: 'do_not_specify_in_manifest',
+        }
+
+        type_definition.create_attribute_in(self, :rsapi_custom_insync_trigger, :newproperty, Puppet::ResourceApi::Property, custom_insync_trigger_options)
+      end
+
       definition[:attributes].each do |name, options|
         # puts "#{name}: #{options.inspect}"
 
@@ -189,43 +220,7 @@ module Puppet::ResourceApi
           parent = Puppet::ResourceApi::Property
         end
 
-        # This call creates a new parameter or property with all work-arounds or
-        # customizations required by the Resource API applied. Under the hood,
-        # this maps to the relevant DSL methods in Puppet::Type. See
-        # https://puppet.com/docs/puppet/6.0/custom_types.html#reference-5883
-        # for details.
-        send(param_or_property, name.to_sym, parent: parent) do
-          if options[:desc]
-            desc "#{options[:desc]} (a #{options[:type]})"
-          end
-
-          # The initialize method is called when puppet core starts building up
-          # type objects. The core passes in a hash of shape { resource:
-          # #<Puppet::Type::TypeName> }. We use this to pass through the
-          # required configuration data to the parent (see
-          # Puppet::ResourceApi::Property, Puppet::ResourceApi::Parameter and
-          # Puppet::ResourceApi::ReadOnlyParameter).
-          define_method(:initialize) do |resource_hash|
-            super(definition[:name], self.class.data_type, name, resource_hash)
-          end
-
-          # get pops data type object for this parameter or property
-          define_singleton_method(:data_type) do
-            @rsapi_data_type ||= Puppet::ResourceApi::DataTypeHandling.parse_puppet_type(
-              name,
-              options[:type],
-            )
-          end
-
-          # from ValueCreator call create_values which makes alias values and
-          # default values for properties and params
-          Puppet::ResourceApi::ValueCreator.create_values(
-            self,
-            data_type,
-            param_or_property,
-            options,
-          )
-        end
+        type_definition.create_attribute_in(self, name, param_or_property, parent, options)
       end
 
       def self.instances
@@ -279,11 +274,9 @@ module Puppet::ResourceApi
       end
 
       def retrieve
-        refresh_current_state unless @rsapi_current_state
+        Puppet.debug("Current State: #{rsapi_current_state.inspect}")
 
-        Puppet.debug("Current State: #{@rsapi_current_state.inspect}")
-
-        result = Puppet::Resource.new(self.class, title, parameters: @rsapi_current_state)
+        result = Puppet::Resource.new(self.class, title, parameters: rsapi_current_state)
         # puppet needs ensure to be a symbol
         result[:ensure] = result[:ensure].to_sym if type_definition.ensurable? && result[:ensure].is_a?(String)
 
@@ -302,10 +295,7 @@ module Puppet::ResourceApi
         raise_missing_attrs
 
         # puts 'flush'
-        # skip puppet's injected metaparams
-        actual_params = @parameters.select { |k, _v| type_definition.attributes.key? k }
-        target_state = Hash[actual_params.map { |k, v| [k, v.rs_value] }]
-        target_state = my_provider.canonicalize(context, [target_state]).first if type_definition.feature?('canonicalize')
+        target_state = rsapi_canonicalized_target_state
 
         retrieve unless @rsapi_current_state
 

--- a/lib/puppet/resource_api/base_context.rb
+++ b/lib/puppet/resource_api/base_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppet/resource_api/type_definition'
 
 # rubocop:disable Style/Documentation

--- a/lib/puppet/resource_api/data_type_handling.rb
+++ b/lib/puppet/resource_api/data_type_handling.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation,Style/ClassAndModuleChildren
 
 # This module is used to handle data inside types, contains methods for munging

--- a/lib/puppet/resource_api/glue.rb
+++ b/lib/puppet/resource_api/glue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 
 module Puppet; end # rubocop:disable Style/Documentation

--- a/lib/puppet/resource_api/glue.rb
+++ b/lib/puppet/resource_api/glue.rb
@@ -57,9 +57,9 @@ module Puppet::ResourceApi
       values
     end
 
-    # attribute names that are not title or namevars
+    # attribute names that are not title, namevars, or rsapi_custom_insync_trigger
     def filtered_keys
-      values.keys.reject { |k| k == :title || !attr_def[k] || (attr_def[k][:behaviour] == :namevar && @namevars.size == 1) }
+      values.keys.reject { |k| k == :title || k == :rsapi_custom_insync_trigger || !attr_def[k] || (attr_def[k][:behaviour] == :namevar && @namevars.size == 1) }
     end
   end
 

--- a/lib/puppet/resource_api/io_context.rb
+++ b/lib/puppet/resource_api/io_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppet/resource_api/base_context'
 
 # Implement Resource API Conext to log through an IO object, defaulting to `$stderr`.

--- a/lib/puppet/resource_api/parameter.rb
+++ b/lib/puppet/resource_api/parameter.rb
@@ -13,7 +13,7 @@ class Puppet::ResourceApi::Parameter < Puppet::Parameter
   # @param attribute_name the name of attribue of the parameter
   # @param resource_hash the resource hash instance which is passed to the
   # parent class.
-  def initialize(type_name, data_type, attribute_name, resource_hash)
+  def initialize(type_name, data_type, attribute_name, resource_hash, _referrable_type = nil)
     @type_name = type_name
     @data_type = data_type
     @attribute_name = attribute_name

--- a/lib/puppet/resource_api/parameter.rb
+++ b/lib/puppet/resource_api/parameter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppet/util'
 require 'puppet/parameter'
 

--- a/lib/puppet/resource_api/property.rb
+++ b/lib/puppet/resource_api/property.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppet/util'
 require 'puppet/property'
 

--- a/lib/puppet/resource_api/puppet_context.rb
+++ b/lib/puppet/resource_api/puppet_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppet/resource_api/base_context'
 require 'puppet/util/logging'
 

--- a/lib/puppet/resource_api/read_only_parameter.rb
+++ b/lib/puppet/resource_api/read_only_parameter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppet/util'
 require 'puppet/resource_api/parameter'
 

--- a/lib/puppet/resource_api/simple_provider.rb
+++ b/lib/puppet/resource_api/simple_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puppet; end # rubocop:disable Style/Documentation
 
 module Puppet::ResourceApi

--- a/lib/puppet/resource_api/transport.rb
+++ b/lib/puppet/resource_api/transport.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puppet::ResourceApi; end # rubocop:disable Style/Documentation
 
 # Remote target transport API

--- a/lib/puppet/resource_api/transport/wrapper.rb
+++ b/lib/puppet/resource_api/transport/wrapper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppet/resource_api/transport'
 require 'hocon'
 require 'hocon/config_syntax'

--- a/lib/puppet/resource_api/type_definition.rb
+++ b/lib/puppet/resource_api/type_definition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Provides accessor methods for the type being provided
 module Puppet::ResourceApi
   # pre-declare class
@@ -15,7 +17,7 @@ module Puppet::ResourceApi
 
     # rubocop complains when this is named has_feature?
     def feature?(feature)
-      (definition[:features] && definition[:features].include?(feature))
+      definition[:features]&.include?(feature)
     end
 
     def title_patterns

--- a/lib/puppet/resource_api/type_definition.rb
+++ b/lib/puppet/resource_api/type_definition.rb
@@ -34,9 +34,55 @@ module Puppet::ResourceApi
       Puppet::ResourceApi::DataTypeHandling.validate_ensure(definition)
 
       definition[:features] ||= []
-      supported_features = %w[supports_noop canonicalize remote_resource simple_get_filter].freeze
+      supported_features = %w[supports_noop canonicalize custom_insync remote_resource simple_get_filter].freeze
       unknown_features = definition[:features] - supported_features
       Puppet.warning("Unknown feature detected: #{unknown_features.inspect}") unless unknown_features.empty?
+    end
+
+    # This call creates a new parameter or property with all work-arounds or
+    # customizations required by the Resource API applied. Under the hood,
+    # this maps to the relevant DSL methods in Puppet::Type. See
+    # https://puppet.com/docs/puppet/6.0/custom_types.html#reference-5883
+    # for details.
+    #
+    # type: the Resource API Type the attribute is being created in
+    # attribute_name: the name of the attribute being created
+    # param_or_property: Whether to call the :newparam or :newproperty method
+    # parent: The type of attribute to create: Property, ReadOnly, or Parameter
+    # options: The hash of attribute options, including type, desc, default, and behaviour
+    def create_attribute_in(type, attribute_name, param_or_property, parent, options)
+      type.send(param_or_property, attribute_name.to_sym, parent: parent) do
+        if options[:desc]
+          desc "#{options[:desc]} (a #{options[:type]})"
+        end
+
+        # The initialize method is called when puppet core starts building up
+        # type objects. The core passes in a hash of shape { resource:
+        # #<Puppet::Type::TypeName> }. We use this to pass through the
+        # required configuration data to the parent (see
+        # Puppet::ResourceApi::Property, Puppet::ResourceApi::Parameter and
+        # Puppet::ResourceApi::ReadOnlyParameter).
+        define_method(:initialize) do |resource_hash|
+          super(type.name, self.class.data_type, attribute_name, resource_hash, type)
+        end
+
+        # get pops data type object for this parameter or property
+        define_singleton_method(:data_type) do
+          @rsapi_data_type ||= Puppet::ResourceApi::DataTypeHandling.parse_puppet_type(
+            attribute_name,
+            options[:type],
+          )
+        end
+
+        # from ValueCreator call create_values which makes alias values and
+        # default values for properties and params
+        Puppet::ResourceApi::ValueCreator.create_values(
+          self,
+          data_type,
+          param_or_property,
+          options,
+        )
+      end
     end
   end
 
@@ -88,6 +134,13 @@ module Puppet::ResourceApi
       }.keys
     end
 
+    def insyncable_attributes
+      @insyncable_attributes ||= attributes.reject { |_name, options|
+        # Only attributes without any behavior are normal Puppet Properties and get insynced
+        options.key?(:behaviour)
+      }.keys
+    end
+
     def validate_schema(definition, attr_key)
       raise Puppet::DevError, '%{type_class} must be a Hash, not `%{other_type}`' % { type_class: self.class.name, other_type: definition.class } unless definition.is_a?(Hash)
       @attributes = definition[attr_key]
@@ -110,6 +163,7 @@ module Puppet::ResourceApi
       Puppet.warning('`%{name}` has no documentation, add it using a `desc` key' % { name: definition[:name] }) unless definition.key? :desc
 
       attributes.each do |key, attr|
+        raise Puppet::DevError, '`rsapi_custom_insync_trigger` cannot be specified as an attribute; it is reserved for propertyless types with the custom_insync feature' if key == :rsapi_custom_insync_trigger # rubocop:disable Metrics/LineLength
         raise Puppet::DevError, "`#{definition[:name]}.#{key}` must be a Hash, not a #{attr.class}" unless attr.is_a? Hash
         raise Puppet::DevError, "`#{definition[:name]}.#{key}` has no type" unless attr.key? :type
         Puppet.warning('`%{name}.%{key}` has no documentation, add it using a `desc` key' % { name: definition[:name], key: key }) unless attr.key? :desc

--- a/lib/puppet/resource_api/value_creator.rb
+++ b/lib/puppet/resource_api/value_creator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puppet; module ResourceApi; end; end # predeclare the main module # rubocop:disable Style/Documentation,Style/ClassAndModuleChildren
 
 # This module is responsible for setting default and alias values for the

--- a/lib/puppet/resource_api/version.rb
+++ b/lib/puppet/resource_api/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Puppet
   module ResourceApi
-    VERSION = '1.8.14'.freeze
+    VERSION = '1.8.14'
   end
 end

--- a/lib/puppet/util/network_device/simple/device.rb
+++ b/lib/puppet/util/network_device/simple/device.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'hocon'
 require 'hocon/config_syntax'
 

--- a/spec/acceptance/array_spec.rb
+++ b/spec/acceptance/array_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tempfile'
 

--- a/spec/acceptance/boolean_spec.rb
+++ b/spec/acceptance/boolean_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tempfile'
 

--- a/spec/acceptance/composite_namevar_spec.rb
+++ b/spec/acceptance/composite_namevar_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'open3'
 require 'spec_helper'
 require 'tempfile'

--- a/spec/acceptance/custom_insync_spec.rb
+++ b/spec/acceptance/custom_insync_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tempfile'
 

--- a/spec/acceptance/custom_insync_spec.rb
+++ b/spec/acceptance/custom_insync_spec.rb
@@ -1,0 +1,271 @@
+require 'spec_helper'
+require 'tempfile'
+
+RSpec.describe 'a provider using custom insync' do
+  describe 'using `puppet apply`' do
+    subject(:puppet_apply_stdout) do
+      stdout_str, _status = Open3.capture2e("puppet apply --verbose --trace --strict=error --modulepath spec/fixtures -e \"#{manifest}\"")
+      stdout_str
+    end
+
+    context 'when an error is raised during insync?' do
+      let(:raising_resource_declaration) { "test_custom_insync { example: ensure => 'present', case_insensitive_string => 'RaiseError' }" }
+      let(:manifest) { raising_resource_declaration.dup }
+
+      it 'reports the error with stack trace and change failure' do
+        expect(puppet_apply_stdout).to match %r{Error:}
+        expect(puppet_apply_stdout).to match %r{block in def_custom_insync?}
+        expect(puppet_apply_stdout).to match %r{change from 'FooBar' to 'RaiseError' failed}
+      end
+
+      context 'with a dependent resource' do
+        let(:dependent_resource_declaration) do
+          "test_custom_insync { dependent: ensure => 'present', case_insensitive_string => 'foobar', require => Test_custom_insync['example'] }"
+        end
+        let(:manifest) { "#{raising_resource_declaration} #{dependent_resource_declaration}" }
+
+        it 'skips dependent resource because of failed dependencies' do
+          expect(puppet_apply_stdout).to match %r{Test_custom_insync\[dependent\]: Skipping because of failed dependencies}
+        end
+      end
+    end
+
+    context 'when handling subset array comparisons' do
+      let(:manifest) { "test_custom_insync { example: ensure => 'present', some_array => #{test_value} }" }
+
+      context 'when the should array is an exact match for the actual value' do
+        let(:test_value) { %w[a b] }
+
+        it 'makes no changes and does not error' do
+          expect(puppet_apply_stdout).not_to match %r{Updating}
+          expect(puppet_apply_stdout).not_to match %r{Error:}
+        end
+      end
+
+      context 'when the should array members are all included in the actual value' do
+        let(:test_value) { ['a'] }
+
+        it 'makes no changes and does not error' do
+          expect(puppet_apply_stdout).not_to match %r{Updating}
+          expect(puppet_apply_stdout).not_to match %r{Error:}
+        end
+      end
+
+      context 'when the the actual value is missing a should array member' do
+        let(:test_value) { %w[a b c] }
+
+        it 'makes no changes and does not error' do
+          expect(puppet_apply_stdout).to match %r{Adding missing members \["c"\]}
+          expect(puppet_apply_stdout).to match %r{Updating}
+          expect(puppet_apply_stdout).not_to match %r{Error:}
+        end
+      end
+    end
+
+    context 'when handling forced array comparisons' do
+      let(:manifest) { "test_custom_insync { example: ensure => 'present', some_array => #{test_value}, force => true }" }
+
+      context 'when the should array is an exact match for the actual value' do
+        let(:test_value) { %w[a b] }
+
+        it 'makes no changes and does not error' do
+          expect(puppet_apply_stdout).not_to match %r{Updating}
+          expect(puppet_apply_stdout).not_to match %r{Error:}
+        end
+      end
+
+      context 'when the should array is an order insensitive match for the actual value' do
+        let(:test_value) { %w[b a] }
+
+        it 'makes no changes and does not error' do
+          expect(puppet_apply_stdout).not_to match %r{Updating}
+          expect(puppet_apply_stdout).not_to match %r{Error:}
+        end
+      end
+
+      context 'when the actual value includes members not found in the should array' do
+        let(:test_value) { ['a'] }
+
+        it 'removes the additional member from the array without erroring' do
+          expect(puppet_apply_stdout).to match %r{some_array changed \['a', 'b'\] to \['a'\]}
+          expect(puppet_apply_stdout).to match %r{Updating}
+          expect(puppet_apply_stdout).not_to match %r{Error:}
+        end
+      end
+
+      context 'when the the actual value is missing a should array member' do
+        let(:test_value) { %w[a b c] }
+
+        it 'adds the missing member to the array without erroring' do
+          expect(puppet_apply_stdout).to match %r{some_array changed \['a', 'b'\] to \['a', 'b', 'c'\]}
+          expect(puppet_apply_stdout).to match %r{Updating}
+          expect(puppet_apply_stdout).not_to match %r{Error:}
+        end
+      end
+    end
+
+    context 'when handling case sensitive string comparisons' do
+      let(:manifest) { "test_custom_insync { example: ensure => 'present', case_sensitive_string => '#{test_value}' }" }
+
+      context 'when the strings match exactly' do
+        let(:test_value) { 'FooBar' }
+
+        it 'makes no changes and does not error' do
+          expect(puppet_apply_stdout).not_to match %r{Updating}
+          expect(puppet_apply_stdout).not_to match %r{Error:}
+        end
+      end
+
+      context 'when the strings differ' do
+        let(:test_value) { 'foobar' }
+
+        it 'changes the string value without erroring' do
+          expect(puppet_apply_stdout).to match %r{case_sensitive_string changed 'FooBar' to 'foobar'}
+          expect(puppet_apply_stdout).to match %r{Updating}
+          expect(puppet_apply_stdout).not_to match %r{Error:}
+        end
+      end
+    end
+
+    context 'when handling case insensitive string comparisons' do
+      let(:manifest) { "test_custom_insync { example: ensure => 'present', case_insensitive_string => '#{test_value}' }" }
+
+      context 'when the strings match exactly' do
+        let(:test_value) { 'FooBar' }
+
+        it 'makes no changes and does not error' do
+          expect(puppet_apply_stdout).not_to match %r{Updating}
+          expect(puppet_apply_stdout).not_to match %r{Error:}
+        end
+      end
+
+      context 'when the strings match exactly except for casing' do
+        let(:test_value) { 'foobar' }
+
+        it 'makes no changes and does not error' do
+          expect(puppet_apply_stdout).not_to match %r{Updating}
+          expect(puppet_apply_stdout).not_to match %r{Error:}
+        end
+      end
+
+      context 'when the strings differ' do
+        let(:test_value) { 'FooBarBaz' }
+
+        it 'changes the string value without erroring' do
+          expect(puppet_apply_stdout).to match %r{case_insensitive_string changed 'FooBar' to 'FooBarBaz'}
+          expect(puppet_apply_stdout).to match %r{Updating}
+          expect(puppet_apply_stdout).not_to match %r{Error:}
+        end
+      end
+    end
+
+    context 'when handling versions' do
+      let(:manifest) { "test_custom_insync { example: ensure => 'present', #{test_key_value_pairs} }" }
+
+      context 'when handling exact version strings' do
+        context 'when the should and actual versions are identical' do
+          let(:test_key_value_pairs) { "version => '1.2.3'" }
+
+          it 'makes no changes and does not error' do
+            expect(puppet_apply_stdout).not_to match %r{Updating}
+            expect(puppet_apply_stdout).not_to match %r{Error:}
+          end
+        end
+
+        context 'when the should and actual versions differ' do
+          let(:test_key_value_pairs) { "version => '3.2.1'" }
+
+          it 'changes the version without erroring' do
+            expect(puppet_apply_stdout).to match %r{version changed '1.2.3' to '3.2.1'}
+            expect(puppet_apply_stdout).to match %r{Updating}
+            expect(puppet_apply_stdout).not_to match %r{Error:}
+          end
+        end
+      end
+
+      context 'when handling custom version strings' do
+        context 'when the custom version string comparison is satisfied by the actual value' do
+          let(:test_key_value_pairs) { "version => '> 1.0.0'" }
+
+          it 'makes no changes and does not error' do
+            expect(puppet_apply_stdout).not_to match %r{Updating}
+            expect(puppet_apply_stdout).not_to match %r{Error:}
+          end
+        end
+
+        context 'when the custom version string comparison is not satisfied by the actual value' do
+          let(:test_key_value_pairs) { "version => '> 2.0.0'" }
+
+          it 'changes to a satisfactory version without erroring' do
+            expect(puppet_apply_stdout).to match %r{The actual version \(1.2.3\) does not meet the custom version bound \(> 2.0.0\); updating to a version that does}
+            expect(puppet_apply_stdout).to match %r{Updating}
+            expect(puppet_apply_stdout).not_to match %r{Error:}
+          end
+        end
+      end
+
+      context 'when handling minimum version bounds' do
+        context 'when the minimum version bound is satisfied by the actual value' do
+          let(:test_key_value_pairs) { "minimum_version => '1.0.0'" }
+
+          it 'makes no changes and does not error' do
+            expect(puppet_apply_stdout).not_to match %r{Updating}
+            expect(puppet_apply_stdout).not_to match %r{Error:}
+          end
+        end
+
+        context 'when the minimum version bound is not satisfied by the actual value' do
+          let(:test_key_value_pairs) { "minimum_version => '2.0.0'" }
+
+          it 'changes to a satisfactory version without erroring' do
+            expect(puppet_apply_stdout).to match %r{The actual version \(1.2.3\) does not meet the minimum version bound \(2.0.0\); updating to a version that does}
+            expect(puppet_apply_stdout).to match %r{Updating}
+            expect(puppet_apply_stdout).not_to match %r{Error:}
+          end
+        end
+      end
+
+      context 'when handling maximum version bounds' do
+        context 'when the maximum version bound is satisfied by the actual value' do
+          let(:test_key_value_pairs) { "maximum_version => '2.0.0'" }
+
+          it 'makes no changes and does not error' do
+            expect(puppet_apply_stdout).not_to match %r{Updating}
+            expect(puppet_apply_stdout).not_to match %r{Error:}
+          end
+        end
+
+        context 'when the maximum version bound is not satisfied by the actual value' do
+          let(:test_key_value_pairs) { "maximum_version => '1.0.0'" }
+
+          it 'changes to a satisfactory version without erroring' do
+            expect(puppet_apply_stdout).to match %r{The actual version \(1.2.3\) does not meet the maximum version bound \(1.0.0\); updating to a version that does}
+            expect(puppet_apply_stdout).to match %r{Updating}
+            expect(puppet_apply_stdout).not_to match %r{Error:}
+          end
+        end
+      end
+
+      context 'when handling combined minimum and maximum version bounds' do
+        context 'when the combined version bounds are satisfied by the actual value' do
+          let(:test_key_value_pairs) { "minimum_version => '1.0.0', maximum_version => '2.0.0'" }
+
+          it 'makes no changes and does not error' do
+            expect(puppet_apply_stdout).not_to match %r{Updating}
+            expect(puppet_apply_stdout).not_to match %r{Error:}
+          end
+        end
+
+        context 'when the combined version bounds are not satisfied by the actual value' do
+          let(:test_key_value_pairs) { "minimum_version => '1.0.0', maximum_version => '1.2.0'" }
+
+          it 'changes to a satisfactory version without erroring' do
+            expect(puppet_apply_stdout).to match %r{The actual version \(1.2.3\) does not meet the combined minimum \(1.0.0\) and maximum \(1.2.0\) bounds; updating to a version which does.}
+            expect(puppet_apply_stdout).to match %r{Updating}
+            expect(puppet_apply_stdout).not_to match %r{Error:}
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/custom_insync_spec_hidden_property.rb
+++ b/spec/acceptance/custom_insync_spec_hidden_property.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tempfile'
 

--- a/spec/acceptance/custom_insync_spec_hidden_property.rb
+++ b/spec/acceptance/custom_insync_spec_hidden_property.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'tempfile'
+
+RSpec.describe 'a provider using custom insync' do
+  subject(:stdout_str) do
+    stdout_str, _status = Open3.capture2e("puppet apply --verbose --trace --strict=error --modulepath spec/fixtures -e \"#{manifest}\"")
+    stdout_str
+  end
+
+  describe 'using `puppet apply`' do
+    context 'when force is not specified' do
+      let(:manifest) { 'test_custom_insync_hidden_property { example: }' }
+
+      it 'calls insync? against rsapi_custom_insync_trigger, reporting no changes' do
+        expect(stdout_str).not_to match %r{Setting with}
+        expect(stdout_str).not_to match %r{Error:}
+      end
+    end
+
+    context 'when force is specified as true' do
+      let(:manifest) { 'test_custom_insync_hidden_property { example: force => true }' }
+
+      it 'calls insync? against rsapi_custom_insync_trigger, reporting a change' do
+        expect(stdout_str).to match %r{Out of sync!}
+        expect(stdout_str).to match %r{Custom insync logic determined that this resource is out of sync}
+        expect(stdout_str).to match %r{Setting with {:name=>"example", :force=>true}}
+        expect(stdout_str).not_to match %r{Error:}
+      end
+    end
+  end
+end

--- a/spec/acceptance/device_spec.rb
+++ b/spec/acceptance/device_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'open3'
 require 'puppet/version'
 require 'spec_helper'

--- a/spec/acceptance/failure_spec.rb
+++ b/spec/acceptance/failure_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tempfile'
 

--- a/spec/acceptance/metaparam_spec.rb
+++ b/spec/acceptance/metaparam_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'open3'

--- a/spec/acceptance/multi_device_spec.rb
+++ b/spec/acceptance/multi_device_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'open3'
 require 'puppet/version'
 require 'spec_helper'

--- a/spec/acceptance/namevar_spec.rb
+++ b/spec/acceptance/namevar_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'open3'
 

--- a/spec/acceptance/noop_spec.rb
+++ b/spec/acceptance/noop_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'open3'

--- a/spec/acceptance/provider_validation_spec.rb
+++ b/spec/acceptance/provider_validation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'open3'

--- a/spec/acceptance/purge_spec.rb
+++ b/spec/acceptance/purge_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tempfile'
 

--- a/spec/acceptance/sensitive_spec.rb
+++ b/spec/acceptance/sensitive_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tempfile'
 require 'open3'

--- a/spec/acceptance/simple_get_filter_spec.rb
+++ b/spec/acceptance/simple_get_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'open3'

--- a/spec/acceptance/transport/transport_spec.rb
+++ b/spec/acceptance/transport/transport_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tempfile'
 require 'open3'

--- a/spec/acceptance/validation_spec.rb
+++ b/spec/acceptance/validation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'open3'

--- a/spec/classes/autorequire_cycle_spec.rb
+++ b/spec/classes/autorequire_cycle_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'test_module::autorequire_cycle' do

--- a/spec/classes/titles_spec.rb
+++ b/spec/classes/titles_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'test_module::titles' do

--- a/spec/fixtures/test_module/lib/puppet/provider/test_custom_insync/test_custom_insync.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/test_custom_insync/test_custom_insync.rb
@@ -1,0 +1,82 @@
+require 'puppet/resource_api'
+require 'puppet/resource_api/simple_provider'
+
+# Implementation for the test_bool type using the Resource API.
+class Puppet::Provider::TestCustomInsync::TestCustomInsync < Puppet::ResourceApi::SimpleProvider
+  def get(_context)
+    [
+      {
+        name: 'example',
+        ensure: 'present',
+        some_array: ['a', 'b'],
+        case_sensitive_string: 'FooBar',
+        case_insensitive_string: 'FooBar',
+        version: '1.2.3',
+      },
+      {
+        name: 'dependent',
+        ensure: 'present',
+        some_array: ['a', 'b'],
+        case_sensitive_string: 'FooBar',
+        case_insensitive_string: 'FooBar',
+        version: '1.2.3',
+      },
+    ]
+  end
+
+  def create(context, name, should)
+    context.notice("Creating '#{name}' with #{should.inspect}")
+  end
+
+  def update(context, name, should)
+    context.notice("Updating '#{name}' with #{should.inspect}")
+  end
+
+  def delete(context, name)
+    context.notice("Deleting '#{name}'")
+  end
+
+  def version_insync?(context, is_hash, should_hash)
+    if should_hash[:version] == ''
+      if should_hash[:minimum_version] || should_hash[:maximum_version]
+        context.notice('Checking a min/max version')
+        meets_minimum_expectation = Gem::Version.new(is_hash[:version]) >= Gem::Version.new(should_hash[:minimum_version]) unless should_hash[:minimum_version].nil?
+        meets_maximum_expectation = Gem::Version.new(is_hash[:version]) <= Gem::Version.new(should_hash[:maximum_version]) unless should_hash[:maximum_version].nil?
+        if should_hash[:minimum_version] && should_hash[:maximum_version]
+          return meets_minimum_expectation && meets_maximum_expectation ? true : "The actual version (#{is_hash[:version]}) does not meet the combined minimum (#{should_hash[:minimum_version]}) and maximum (#{should_hash[:maximum_version]}) bounds; updating to a version which does."
+        elsif should_hash[:minimum_version]
+          return meets_minimum_expectation ? true : "The actual version (#{is_hash[:version]}) does not meet the minimum version bound (#{should_hash[:minimum_version]}); updating to a version that does"
+        else
+          return meets_maximum_expectation ? true : "The actual version (#{is_hash[:version]}) does not meet the maximum version bound (#{should_hash[:maximum_version]}); updating to a version that does"
+        end
+      else
+        return true
+      end
+    elsif !should_hash[:version].nil? && should_hash[:version].match?(%r{^\D+\s+})
+      context.notice("Checking a custom version bound")
+      return Gem::Dependency.new('', should_hash[:version]).match?('', is_hash[:version]) ? true : "The actual version (#{is_hash[:version]}) does not meet the custom version bound (#{should_hash[:version]}); updating to a version that does"
+    end
+  end
+
+  def insync?(context, name, property_name, is_hash, should_hash)
+    context.notice("Checking whether #{property_name} is out of sync")
+    case property_name
+    when :some_array
+      if should_hash[:force]
+        context.notice("Checking an order independent array")
+        return is_hash[property_name].sort == should_hash[property_name].sort
+      else
+        context.notice("Checking a subset match array")
+        found_members = (is_hash[property_name] & should_hash[property_name]).sort
+        missing_members = should_hash[property_name].reject { |member| found_members.include?(member) }
+        return missing_members.empty? ? true : "Adding missing members #{missing_members}"
+      end
+    when :case_insensitive_string
+      # Need to show what happens when a comparison fails
+      raise "FAILURE MODE ENGAGED WITH #{property_name} set to '#{should_hash[property_name]}'" if should_hash[property_name].downcase == 'raiseerror'
+      return is_hash[property_name].downcase == should_hash[property_name].downcase
+    when :version
+      return version_insync?(context, is_hash, should_hash)
+    end
+  end
+end

--- a/spec/fixtures/test_module/lib/puppet/provider/test_custom_insync/test_custom_insync.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/test_custom_insync/test_custom_insync.rb
@@ -43,18 +43,18 @@ class Puppet::Provider::TestCustomInsync::TestCustomInsync < Puppet::ResourceApi
         meets_minimum_expectation = Gem::Version.new(is_hash[:version]) >= Gem::Version.new(should_hash[:minimum_version]) unless should_hash[:minimum_version].nil?
         meets_maximum_expectation = Gem::Version.new(is_hash[:version]) <= Gem::Version.new(should_hash[:maximum_version]) unless should_hash[:maximum_version].nil?
         if should_hash[:minimum_version] && should_hash[:maximum_version]
-          return meets_minimum_expectation && meets_maximum_expectation ? true : "The actual version (#{is_hash[:version]}) does not meet the combined minimum (#{should_hash[:minimum_version]}) and maximum (#{should_hash[:maximum_version]}) bounds; updating to a version which does."
+          return meets_minimum_expectation && meets_maximum_expectation ? true : [false, "The actual version (#{is_hash[:version]}) does not meet the combined minimum (#{should_hash[:minimum_version]}) and maximum (#{should_hash[:maximum_version]}) bounds; updating to a version which does."]
         elsif should_hash[:minimum_version]
-          return meets_minimum_expectation ? true : "The actual version (#{is_hash[:version]}) does not meet the minimum version bound (#{should_hash[:minimum_version]}); updating to a version that does"
+          return meets_minimum_expectation ? true : [false, "The actual version (#{is_hash[:version]}) does not meet the minimum version bound (#{should_hash[:minimum_version]}); updating to a version that does"]
         else
-          return meets_maximum_expectation ? true : "The actual version (#{is_hash[:version]}) does not meet the maximum version bound (#{should_hash[:maximum_version]}); updating to a version that does"
+          return meets_maximum_expectation ? true : [false, "The actual version (#{is_hash[:version]}) does not meet the maximum version bound (#{should_hash[:maximum_version]}); updating to a version that does"]
         end
       else
         return true
       end
     elsif !should_hash[:version].nil? && should_hash[:version].match?(%r{^\D+\s+})
       context.notice("Checking a custom version bound")
-      return Gem::Dependency.new('', should_hash[:version]).match?('', is_hash[:version]) ? true : "The actual version (#{is_hash[:version]}) does not meet the custom version bound (#{should_hash[:version]}); updating to a version that does"
+      return Gem::Dependency.new('', should_hash[:version]).match?('', is_hash[:version]) ? true : [false, "The actual version (#{is_hash[:version]}) does not meet the custom version bound (#{should_hash[:version]}); updating to a version that does"]
     end
   end
 
@@ -69,7 +69,7 @@ class Puppet::Provider::TestCustomInsync::TestCustomInsync < Puppet::ResourceApi
         context.notice("Checking a subset match array")
         found_members = (is_hash[property_name] & should_hash[property_name]).sort
         missing_members = should_hash[property_name].reject { |member| found_members.include?(member) }
-        return missing_members.empty? ? true : "Adding missing members #{missing_members}"
+        return missing_members.empty? ? true : [false, "Adding missing members #{missing_members}"]
       end
     when :case_insensitive_string
       # Need to show what happens when a comparison fails

--- a/spec/fixtures/test_module/lib/puppet/provider/test_custom_insync_hidden_property/test_custom_insync_hidden_property.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/test_custom_insync_hidden_property/test_custom_insync_hidden_property.rb
@@ -1,0 +1,27 @@
+require 'puppet/resource_api'
+require 'puppet/resource_api/simple_provider'
+
+# Implementation for the test_custom_insync_hidden_property type using the Resource API.
+class Puppet::Provider::TestCustomInsyncHiddenProperty::TestCustomInsyncHiddenProperty
+  def get(_context)
+    [
+      {
+        name: 'example'
+      }
+    ]
+  end
+
+  def set(context, changes)
+    changes.each do |_name, is_and_should|
+      context.notice("Setting with #{is_and_should[:should].inspect}")
+    end
+  end
+
+  def insync?(context, name, _property_name, is_hash, should_hash)
+    context.notice("Checking whether #{name} is out of sync")
+
+    return true unless should_hash[:force]
+    context.notice("Out of sync!")
+    false
+  end
+end

--- a/spec/fixtures/test_module/lib/puppet/type/test_custom_insync.rb
+++ b/spec/fixtures/test_module/lib/puppet/type/test_custom_insync.rb
@@ -1,0 +1,54 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'test_custom_insync',
+  docs: <<-EOS,
+      This type provides Puppet with the capabilities to manage ...
+    EOS
+  features: ['custom_insync'],
+  attributes:   {
+    ensure:      {
+      type:    'Enum[present, absent]',
+      desc:    'Whether this resource should be present or absent on the target system.',
+      default: 'present',
+    },
+    name:        {
+      type:      'String',
+      desc:      'The name of the resource you want to manage.',
+      behaviour: :namevar,
+    },
+    case_sensitive_string: {
+      type: 'Optional[String]',
+      desc: 'A string which must be case sensitive',
+    },
+    case_insensitive_string: {
+      type: 'Optional[String]',
+      desc: 'A string which need not be case sensitive',
+    },
+    some_array:  {
+      type: 'Optional[Array[String]]',
+      desc: 'An array aiding array attestation',
+    },
+    force: {
+      type:      'Boolean',
+      desc:      'If true, the specified array is inclusive and must match the existing state exactly.',
+      behaviour: :parameter,
+      default:   false,
+    },
+    version:  {
+      type: 'String',
+      desc: 'A version string which may be prepended with a version matcher like "<=" or "~".',
+      default: '',
+    },
+    minimum_version:  {
+      type: 'Optional[String]',
+      desc: 'A version string which current state must not be lower than',
+      behaviour: :parameter,
+    },
+    maximum_version:  {
+      type: 'Optional[String]',
+      desc: 'A version string which current state must not be higher than',
+      behaviour: :parameter,
+    },
+  },
+)

--- a/spec/fixtures/test_module/lib/puppet/type/test_custom_insync_hidden_property.rb
+++ b/spec/fixtures/test_module/lib/puppet/type/test_custom_insync_hidden_property.rb
@@ -1,0 +1,22 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'test_custom_insync_hidden_property',
+  docs: <<-EOS,
+      This type provides Puppet with the capabilities to manage ...
+    EOS
+  features: ['custom_insync'],
+  attributes:   {
+    name:        {
+      type:      'String',
+      desc:      'The name of the resource you want to manage.',
+      behaviour: :namevar,
+    },
+    force: {
+      type:      'Boolean',
+      desc:      'If true, the resource will be treated as not being insync.',
+      behaviour: :parameter,
+      default:   false,
+    },
+  },
+)

--- a/spec/fixtures/test_module/spec/unit/puppet/provider/test_custom_insync/test_custom_insync_spec.rb
+++ b/spec/fixtures/test_module/spec/unit/puppet/provider/test_custom_insync/test_custom_insync_spec.rb
@@ -1,0 +1,206 @@
+require 'spec_helper'
+
+# TODO: needs some cleanup/helper to avoid this misery
+module Puppet::Provider::TestCustomInsync; end
+require 'puppet/provider/test_custom_insync/test_custom_insync'
+
+RSpec.describe Puppet::Provider::TestCustomInsync::TestCustomInsync do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+  let(:name) { 'example' }
+  let(:base_should_hash) { { name: 'example', ensure: 'present' } }
+  let(:is_hash) do
+    {
+      name: 'example',
+      ensure: 'present',
+      some_array: ['a', 'b'],
+      case_sensitive_string: 'FooBar',
+      case_insensitive_string: 'FooBar',
+      version: '1.2.3',
+    }
+  end
+
+  describe '#get' do
+    it 'processes resources' do
+      expect(provider.get(context)).to eq [is_hash]
+    end
+  end
+
+  describe 'insync?(context, name, property_name, is_hash, should_hash)' do
+    subject { provider.insync?(context, name, property_name, is_hash, should_hash) }
+
+    before(:each) do
+      allow(context).to receive(:notice).with(%r{\AChecking whether #{property_name.to_s} is out of sync})
+    end
+
+    context 'when handling arrays' do
+      let(:property_name) { :some_array }
+
+      context 'when handling order independent arrays' do
+        before(:each) do
+          allow(context).to receive(:notice).with(%r{\AChecking an order independent array})
+        end
+
+        context 'when the actual value is an exact match' do
+          let(:should_hash) { base_should_hash.merge({ some_array: ['a', 'b'], force: true }) }
+
+          it {is_expected.to be true }
+        end
+
+        context 'when the actual value is an order insensitive match' do
+          let(:should_hash) { base_should_hash.merge({ some_array: ['b', 'a'], force: true }) }
+
+          it {is_expected.to be true }
+        end
+
+        context 'when the actual value is missing an array member' do
+          let(:should_hash) { base_should_hash.merge({ some_array: ['c'], force: true }) }
+
+          it {is_expected.to be false }
+        end
+
+        context 'when the actual value has an extra array member' do
+          let(:should_hash) { base_should_hash.merge({ some_array: ['a'], force: true }) }
+
+          it {is_expected.to be false }
+        end
+      end
+
+      context 'when handling subset match arrays' do
+        let(:should_hash) { base_hash.merge({ some_array: ['a', 'b'] }) }
+
+        before(:each) do
+          allow(context).to receive(:notice).with(%r{\AChecking a subset match array})
+        end
+
+        context 'when the actual value is an exact match' do
+          let(:should_hash) { base_should_hash.merge({ some_array: ['a', 'b'] }) }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the actual value is missing an array member' do
+          let(:should_hash) { base_should_hash.merge({ some_array: ['c'] }) }
+
+          it { is_expected.to eq 'Adding missing members ["c"]' }
+        end
+
+        context 'when the actual value has an extra array member' do
+          let(:should_hash) { base_should_hash.merge({ some_array: ['a'] }) }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    context 'when handling strings' do
+      context 'case sensitively' do
+        let(:property_name) { :case_sensitive_string }
+        let(:should_hash) { base_should_hash.merge({ case_sensitive_string: 'FooBar' })}
+
+        it 'falls back on Puppet::Property.insync? for comparison, returning nil' do
+          expect(subject).to be nil
+        end
+      end
+
+      context 'case insensitively' do
+        let(:property_name) { :case_insensitive_string }
+
+        context 'when the value is an exact match' do
+          let(:should_hash) { base_should_hash.merge({ case_insensitive_string: 'FooBar' })}
+          it { is_expected.to be true }
+        end
+        context 'when the value is a downcased match' do
+          let(:should_hash) { base_should_hash.merge({ case_insensitive_string: 'foobar' })}
+          it { is_expected.to be true }
+        end
+        context 'when the value is different' do
+          let(:should_hash) { base_should_hash.merge({ case_insensitive_string: 'FooBarBaz' })}
+          it { is_expected.to be false }
+        end
+      end
+    end
+
+    context 'when handling versions' do
+      let(:property_name) { :version }
+
+      context 'exactly' do
+        let(:should_hash) { base_should_hash.merge({ version: '1.2.3' })}
+
+        it 'falls back on Puppet::Property.insync? for comparison, returning nil' do
+          expect(subject).to be nil
+        end
+      end
+
+      context 'with a custom version string' do
+        before(:each) { allow(context).to receive(:notice).with(%r{\AChecking a custom version bound}) }
+
+        context 'when the custom version string is invalid' do
+          let(:should_hash) { base_should_hash.merge({ version: '>!& 1.2.3' }) }
+
+          it 'raises a BadRequirementError via Gem::Requirement' do
+            expect { subject }.to raise_error Gem::Requirement::BadRequirementError
+          end
+        end
+
+        context 'when the custom version string condition is satisfied' do
+          let(:should_hash) { base_should_hash.merge({ version: '> 1.0.0' }) }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when the custom version string condition is not satisfied' do
+          let(:should_hash) { base_should_hash.merge({ version: '> 2.0.0' }) }
+
+          it { is_expected.to eq 'The actual version (1.2.3) does not meet the custom version bound (> 2.0.0); updating to a version that does' }
+        end
+      end
+      context 'with a minimum version bound' do
+        before(:each) { allow(context).to receive(:notice).with(%r{\AChecking a min/max version}) }
+
+        context 'when it is satisfied' do
+          let(:should_hash) { base_should_hash.merge({ version: '', minimum_version: '1.0.0' }) }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when it is not satisfied' do
+          let(:should_hash) { base_should_hash.merge({ version: '', minimum_version: '2.0.0' }) }
+
+          it { is_expected.to eq 'The actual version (1.2.3) does not meet the minimum version bound (2.0.0); updating to a version that does' }
+        end
+      end
+      context 'with a maximum version bound' do
+        before(:each) { allow(context).to receive(:notice).with(%r{\AChecking a min/max version}) }
+
+        context 'when it is satisfied' do
+          let(:should_hash) { base_should_hash.merge({ version: '', maximum_version: '2.0.0' }) }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when it is not satisfied' do
+          let(:should_hash) { base_should_hash.merge({ version: '', maximum_version: '1.0.0' }) }
+
+          it { is_expected.to eq 'The actual version (1.2.3) does not meet the maximum version bound (1.0.0); updating to a version that does' }
+        end
+      end
+      context 'with combined minimum & maximum version bounds' do
+        before(:each) { allow(context).to receive(:notice).with(%r{\AChecking a min/max version}) }
+
+        context 'when they are satisfied' do
+          let(:should_hash) { base_should_hash.merge({ version: '', minimum_version: '1.0.0', maximum_version: '2.0.0' }) }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when they are not satisfied' do
+          let(:should_hash) { base_should_hash.merge({ version: '', minimum_version: '2.0.0', maximum_version: '3.0.0' }) }
+
+          it { is_expected.to eq 'The actual version (1.2.3) does not meet the combined minimum (2.0.0) and maximum (3.0.0) bounds; updating to a version which does.' }
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/test_module/spec/unit/puppet/provider/test_custom_insync_hidden_property/test_custom_insync_hidden_property_spec.rb
+++ b/spec/fixtures/test_module/spec/unit/puppet/provider/test_custom_insync_hidden_property/test_custom_insync_hidden_property_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+# TODO: needs some cleanup/helper to avoid this misery
+module Puppet::Provider::TestCustomInsyncHiddenProperty; end
+require 'puppet/provider/test_custom_insync_hidden_property/test_custom_insync_hidden_property'
+
+RSpec.describe Puppet::Provider::TestCustomInsyncHiddenProperty::TestCustomInsyncHiddenProperty do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+
+  describe '#get' do
+    it 'processes resources and does not return rsapi_custom_insync_trigger' do
+      expect(provider.get(context)).to eq [
+        {
+          name: 'example'
+        }
+      ]
+    end
+  end
+
+  describe 'insync?(context, name, property_name, is_hash, should_hash)' do
+    let(:is_hash) { { name: 'example' } }
+
+    before(:each) do
+      allow(context).to receive(:notice).with(%r{\AChecking whether rsapi_custom_insync_trigger is out of sync})
+    end
+
+    it 'checks insync for rsapi_custom_insync_trigger' do
+      expect { provider.insync?(context, 'example', :rsapi_custom_insync_trigger, is_hash, { name: 'example' }) }.not_to raise_error
+    end
+    it 'returns true if force is not specified as true' do
+      expect(provider.insync?(context, 'example', :rsapi_custom_insync_trigger, is_hash, { name: 'example' })).to be true
+    end
+    it 'returns false if force is specified as true' do
+      expect(context).to receive(:notice).with(%r{\AOut of sync!})
+      expect(provider.insync?(context, 'example', :rsapi_custom_insync_trigger, is_hash, { name: 'example', force: true })).to be false
+    end
+  end
+end

--- a/spec/fixtures/test_module/spec/unit/puppet/provider/test_custom_insync_hidden_property/test_custom_insync_hidden_property_spec.rb
+++ b/spec/fixtures/test_module/spec/unit/puppet/provider/test_custom_insync_hidden_property/test_custom_insync_hidden_property_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Puppet::Provider::TestCustomInsyncHiddenProperty::TestCustomInsyn
     let(:is_hash) { { name: 'example' } }
 
     before(:each) do
-      allow(context).to receive(:notice).with(%r{\AChecking whether rsapi_custom_insync_trigger is out of sync})
+      allow(context).to receive(:notice).with(%r{\AChecking whether example is out of sync})
     end
 
     it 'checks insync for rsapi_custom_insync_trigger' do

--- a/spec/fixtures/test_module/spec/unit/puppet/type/test_custom_insync_hidden_property_spec.rb
+++ b/spec/fixtures/test_module/spec/unit/puppet/type/test_custom_insync_hidden_property_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'puppet/type/test_custom_insync_hidden_property'
+
+RSpec.describe 'the test_custom_insync_hidden_property type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:test_custom_insync_hidden_property)).not_to be_nil
+  end
+end

--- a/spec/integration/resource_api/transport_spec.rb
+++ b/spec/integration/resource_api/transport_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Resource API Transport integration tests:' do

--- a/spec/integration/resource_api_spec.rb
+++ b/spec/integration/resource_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Resource API integrated tests:' do

--- a/spec/puppet/provider/no_class/no_class.rb
+++ b/spec/puppet/provider/no_class/no_class.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 # this file is intentionally left blank for the spec tests of Puppet::ResourceApi#load_provider

--- a/spec/puppet/provider/test_provider/test_provider.rb
+++ b/spec/puppet/provider/test_provider/test_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # this provider is used throughout this test suite
 class Puppet::Provider::TestProvider::TestProvider
 end

--- a/spec/puppet/resource_api/base_context_spec.rb
+++ b/spec/puppet/resource_api/base_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::BaseContext do

--- a/spec/puppet/resource_api/base_type_definition_spec.rb
+++ b/spec/puppet/resource_api/base_type_definition_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::BaseTypeDefinition do

--- a/spec/puppet/resource_api/data_type_handling_spec.rb
+++ b/spec/puppet/resource_api/data_type_handling_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::DataTypeHandling do

--- a/spec/puppet/resource_api/glue_spec.rb
+++ b/spec/puppet/resource_api/glue_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe 'the dirty bits' do
           expect(instance.to_manifest).to eq "typename { 'title': \n# attr_ro => 'fixed', # Read Only\n}"
         end
       end
+
+      context 'with hidden rsapi_custom_insync_trigger property' do
+        subject(:instance) do
+          described_class.new({ namevarname: title, rsapi_custom_insync_trigger: true }, 'typename', [:namevarname],
+                              namevarname: { type: 'String', behaviour: :namevar, desc: 'the title' },
+                              rsapi_custom_insync_trigger: { type: 'Boolean', desc: 'Hidden property' })
+        end
+
+        it 'doesn\'t output the hidden property' do
+          expect(instance.to_manifest).not_to match %r{rsapi_custom_insync_trigger}
+        end
+      end
     end
 
     describe '.to_json' do
@@ -62,6 +74,18 @@ RSpec.describe 'the dirty bits' do
           expect(instance.to_json).to eq '{"title":{"attr_ro":"fixed"}}'
         end
       end
+
+      context 'with hidden rsapi_custom_insync_trigger property' do
+        subject(:instance) do
+          described_class.new({ namevarname: title, rsapi_custom_insync_trigger: true }, 'typename', [:namevarname],
+                              namevarname: { type: 'String', behaviour: :namevar, desc: 'the title' },
+                              rsapi_custom_insync_trigger: { type: 'Boolean', desc: 'Hidden property' })
+        end
+
+        it 'doesn\'t output the hidden property' do
+          expect(instance.to_json).not_to match %r{rsapi_custom_insync_trigger}
+        end
+      end
     end
 
     describe '.to_hierayaml' do
@@ -71,6 +95,18 @@ RSpec.describe 'the dirty bits' do
         let(:title) { "foo:\nbar" }
 
         it { expect(instance.to_hierayaml).to eq "  ? |-\n    foo:\n    bar\n  : attr: value\n    attr_ro: fixed\n" }
+      end
+
+      context 'with hidden rsapi_custom_insync_trigger property' do
+        subject(:instance) do
+          described_class.new({ namevarname: title, rsapi_custom_insync_trigger: true }, 'typename', [:namevarname],
+                              namevarname: { type: 'String', behaviour: :namevar, desc: 'the title' },
+                              rsapi_custom_insync_trigger: { type: 'Boolean', desc: 'Hidden property' })
+        end
+
+        it 'doesn\'t output the hidden property' do
+          expect(instance.to_hierayaml).not_to match %r{rsapi_custom_insync_trigger}
+        end
       end
     end
 

--- a/spec/puppet/resource_api/glue_spec.rb
+++ b/spec/puppet/resource_api/glue_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 # The tests in here are only a light dusting to avoid accidents,

--- a/spec/puppet/resource_api/io_context_spec.rb
+++ b/spec/puppet/resource_api/io_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'puppet/resource_api/io_context'
 
@@ -7,7 +9,7 @@ RSpec.describe Puppet::ResourceApi::IOContext do
   let(:definition) { { name: 'some_resource', attributes: {} } }
   let(:transport) { nil }
 
-  let(:io) { StringIO.new('', 'w') }
+  let(:io) { StringIO.new(+ '', 'w') }
 
   describe '#warning(msg)' do
     it 'outputs the message' do

--- a/spec/puppet/resource_api/parameter_spec.rb
+++ b/spec/puppet/resource_api/parameter_spec.rb
@@ -2,17 +2,18 @@ require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::Parameter do
   subject(:parameter) do
-    described_class.new(type_name, data_type, attribute_name, resource_hash)
+    described_class.new(type_name, data_type, attribute_name, resource_hash, referrable_type)
   end
 
   let(:type_name) { 'test_name' }
   let(:attribute_name) { 'some_parameter' }
   let(:data_type) { Puppet::Pops::Types::PStringType.new(nil) }
   let(:resource_hash) { { resource: {} } }
+  let(:referrable_type) { Puppet::ResourceApi.register_type(name: 'minimal', attributes: {}) }
 
-  describe '#new(type_name, data_type, attribute_name, resource_hash)' do
+  describe '#new(type_name, data_type, attribute_name, resource_hash, referrable_type)' do
     it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
-    it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash) }.not_to raise_error }
+    it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash, referrable_type) }.not_to raise_error }
   end
 
   describe 'value error handling' do

--- a/spec/puppet/resource_api/parameter_spec.rb
+++ b/spec/puppet/resource_api/parameter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::Parameter do

--- a/spec/puppet/resource_api/property_spec.rb
+++ b/spec/puppet/resource_api/property_spec.rb
@@ -2,17 +2,20 @@ require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::Property do
   subject(:property) do
-    described_class.new(type_name, data_type, attribute_name, resource_hash)
+    described_class.new(type_name, data_type, attribute_name, resource_hash, referrable_type)
   end
 
   let(:type_name) { 'test_name' }
   let(:attribute_name) { 'some_property' }
   let(:data_type) { Puppet::Pops::Types::PStringType.new(nil) }
-  let(:resource_hash) { { resource: {} } }
+  let(:resource) { instance_double('resource') }
+  let(:resource_hash) { { resource: resource } }
+  let(:referrable_type) { Puppet::ResourceApi.register_type(name: 'minimal', attributes: {}) }
+  let(:context) { instance_double('Puppet::ResourceApi::PuppetContext') }
 
-  describe '#new(type_name, data_type, attribute_name, resource_hash)' do
+  describe '#new(type_name, data_type, attribute_name, resource_hash, referrable_type)' do
     it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
-    it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash) }.not_to raise_error }
+    it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash, referrable_type) }.not_to raise_error }
   end
 
   describe 'the special :ensure behaviour' do
@@ -22,7 +25,8 @@ RSpec.describe Puppet::ResourceApi::Property do
           super('test_name',
             Puppet::Pops::Types::PEnumType.new(%w[absent present]),
             :ensure,
-            { resource: {} })
+            { resource: {} },
+            Puppet::ResourceApi.register_type(name: 'minimal', attributes: {}))
         end
       end
     end
@@ -50,6 +54,208 @@ RSpec.describe Puppet::ResourceApi::Property do
       it { expect(ensure_property.should).to eq :present }
       it { expect(ensure_property.rs_value).to eq 'present' }
       it { expect(ensure_property.value).to eq :present }
+    end
+  end
+
+  describe 'custom_insync handling' do
+    subject(:custom_insync_property) { custom_insync_property_class.new }
+
+    let(:referrable_type_custom_insync) { Puppet::ResourceApi.register_type(name: type_name, attributes: {}, features: ['custom_insync']) }
+    let(:custom_insync_attribute_name) { :case_sensitive_string }
+    let(:test_provider_with_insync) { instance_double('provider_with_insync') }
+    let(:test_provider_without_insync) { instance_double('provider_without_insync') }
+    let(:custom_insync_property_class) do
+      # This awkward handling is to enable us to reference the referrable type in expectations
+      passable_type_name = type_name
+      passable_data_type = data_type
+      passable_custom_insync_attribute_name = custom_insync_attribute_name
+      passable_resource_hash = resource_hash
+      passable_referrable_type_custom_insync = referrable_type_custom_insync
+      Class.new(described_class) do
+        define_method(:initialize) do
+          super(passable_type_name,
+            passable_data_type,
+            passable_custom_insync_attribute_name,
+            passable_resource_hash,
+            passable_referrable_type_custom_insync
+          )
+        end
+      end
+    end
+
+    context 'when the custom insync feature flag is not specified in the type' do
+      before(:each) do
+        property.should = 'foo'
+      end
+
+      it 'does not add custom insync handling' do
+        expect(resource).not_to receive(:rsapi_canonicalized_target_state)
+        expect(resource).not_to receive(:rsapi_current_state)
+        expect(resource).not_to receive(:rsapi_title)
+        expect(property.insync?('foo')).to be true
+      end
+    end
+
+    context 'when the custom insync feature flag is specified in the type' do
+      before(:each) do
+        allow(resource).to receive(:rsapi_canonicalized_target_state)
+        allow(resource).to receive(:rsapi_current_state)
+        allow(resource).to receive(:rsapi_title)
+        allow(referrable_type_custom_insync).to receive(:context).and_return(context)
+      end
+
+      context 'when calling insync?' do
+        before(:each) do
+          custom_insync_property.should = 'foo'
+        end
+
+        context 'when insync? is not defined in the provider' do
+          it 'raises an error' do
+            expect(referrable_type_custom_insync).to receive(:my_provider).and_return(test_provider_without_insync)
+            expect { custom_insync_property.insync?('Foo') }.to raise_error Puppet::DevError, %r{No insync\? method defined in the provider}
+          end
+        end
+
+        context 'when insync? is defined in the provider' do
+          before(:each) do
+            allow(referrable_type_custom_insync).to receive(:my_provider).and_return(test_provider_with_insync)
+          end
+
+          context 'when custom insync from the provider returns nil' do
+            it 'relies on the comparison in Puppet::Property.insync? if the attribute name is not ensure' do
+              allow(test_provider_with_insync).to receive(:insync?).and_return(nil)
+              expect(custom_insync_property.insync?('Foo')).to be false
+            end
+
+            context 'when the property is ensure' do
+              let(:ensure_property_class) do
+                Class.new(described_class) do
+                  define_method(:initialize) do
+                    super('test_name',
+                      Puppet::Pops::Types::PEnumType.new(%w[absent present]),
+                      :ensure,
+                      { resource: {} },
+                      Puppet::ResourceApi.register_type(name: 'minimal', attributes: {}))
+                  end
+                end
+              end
+              let(:ensure_property) { ensure_property_class.new }
+
+              before(:each) do
+                allow(Puppet::ResourceApi::DataTypeHandling).to receive(:mungify)
+                  .with(Puppet::Pops::Types::PEnumType.new(%w[absent present]), 'present', 'test_name.ensure', false)
+                  .and_return('present')
+
+                ensure_property.should = 'present'
+              end
+
+              it 'compares using symbols' do
+                expect(ensure_property.insync?(:present)).to eq(true)
+              end
+            end
+          end
+
+          context 'when custom insync from the provider returns a boolean' do
+            it 'returns true if the result was true' do
+              expect(test_provider_with_insync).to receive(:insync?).and_return(true)
+              expect(custom_insync_property.insync?('Foo')).to be true
+            end
+            it 'returns false if result was false' do
+              expect(test_provider_with_insync).to receive(:insync?).and_return(false)
+              expect(custom_insync_property.insync?('Foo')).to be false
+            end
+          end
+
+          context 'when custom insync from the provider returns a string' do
+            it 'returns false if custom insync from the provider returns a string' do
+              expect(test_provider_with_insync).to receive(:insync?).and_return('custom change report message')
+              expect(custom_insync_property.insync?('Foo')).to be false
+            end
+          end
+
+          context 'when custom insync from the provider returns an invalid result' do
+            it 'writes a warning and returns false' do
+              expect(test_provider_with_insync).to receive(:insync?).and_return({})
+              expect(context).to receive(:warning).with("Custom insync for #{custom_insync_attribute_name} returned a Hash instead of a String")
+              expect(custom_insync_property.insync?('Foo')).to be false
+            end
+          end
+        end
+      end
+
+      context 'when calling change_to_s' do
+        before(:each) do
+          allow(resource).to receive(:rsapi_canonicalized_target_state)
+          allow(resource).to receive(:rsapi_current_state)
+          allow(resource).to receive(:rsapi_title)
+          allow(referrable_type_custom_insync).to receive(:context).and_return(context)
+          allow(referrable_type_custom_insync).to receive(:my_provider).and_return(test_provider_with_insync)
+        end
+
+        context 'when the property is not rsapi_custom_insync_trigger' do
+          before(:each) do
+            custom_insync_property.should = 'foo'
+          end
+
+          context 'when insync? returned a boolean' do
+            it 'relies on Puppet::Property.change_to_s for change reporting' do
+              expect(test_provider_with_insync).to receive(:insync?).and_return(false)
+              custom_insync_property.insync?('Foo')
+              expect(custom_insync_property.change_to_s('Foo', 'foo')).to match(%r{changed 'Foo' to 'foo'})
+            end
+          end
+
+          context 'when insync? returned nil' do
+            it 'relies on Puppet::Property.change_to_s for change reporting' do
+              expect(test_provider_with_insync).to receive(:insync?).and_return(nil)
+              custom_insync_property.insync?('Foo')
+              expect(custom_insync_property.change_to_s('Foo', 'foo')).to match(%r{changed 'Foo' to 'foo'})
+            end
+          end
+
+          context 'when insync? returned a string' do
+            let(:insync_result) { 'Custom Change Notification' }
+
+            it 'passes the string returned by insync? for change reporting' do
+              expect(test_provider_with_insync).to receive(:insync?).and_return(insync_result)
+              custom_insync_property.insync?('Foo')
+              expect(custom_insync_property.change_to_s('Foo', 'foo')).to eq insync_result
+            end
+          end
+
+          context 'when insync? returned something else' do
+            let(:insync_result) { ['a'] }
+
+            it 'relies on Puppet::Property.change_to_s for change reporting' do
+              expect(test_provider_with_insync).to receive(:insync?).and_return(insync_result)
+              expect(context).to receive(:warning)
+              custom_insync_property.insync?('Foo')
+              expect(custom_insync_property.change_to_s('Foo', insync_result)).to match(%r{changed 'Foo' to \['a'\]})
+            end
+          end
+        end
+
+        context 'when the property is rsapi_custom_insync_trigger' do
+          let(:insync_result) { 'Custom Change Notification' }
+          let(:custom_insync_attribute_name) { :rsapi_custom_insync_trigger }
+          let(:data_type) { Puppet::Pops::Types::PBooleanType.new }
+
+          before(:each) do
+            custom_insync_property.should = true
+          end
+
+          it 'passes the default message for change reporting if insync? did not return a string' do
+            expect(test_provider_with_insync).to receive(:insync?).and_return(false)
+            custom_insync_property.insync?('Foo')
+            expect(custom_insync_property.change_to_s(false, true)).to match(%r{Custom insync logic determined that this resource is out of sync})
+          end
+          it 'passes the string returned by insync? for change reporting' do
+            expect(test_provider_with_insync).to receive(:insync?).and_return(insync_result)
+            custom_insync_property.insync?('Foo')
+            expect(custom_insync_property.change_to_s(false, true)).to be insync_result
+          end
+        end
+      end
     end
   end
 

--- a/spec/puppet/resource_api/property_spec.rb
+++ b/spec/puppet/resource_api/property_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::Property do

--- a/spec/puppet/resource_api/puppet_context_spec.rb
+++ b/spec/puppet/resource_api/puppet_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::PuppetContext do

--- a/spec/puppet/resource_api/read_only_parameter_spec.rb
+++ b/spec/puppet/resource_api/read_only_parameter_spec.rb
@@ -2,17 +2,18 @@ require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::ReadOnlyParameter do
   subject(:read_only_parameter) do
-    described_class.new(type_name, data_type, attribute_name, resource_hash)
+    described_class.new(type_name, data_type, attribute_name, resource_hash, referrable_type)
   end
 
   let(:type_name) { 'test_name' }
   let(:attribute_name) { 'some_parameter' }
   let(:data_type) { Puppet::Pops::Types::PStringType.new(nil) }
   let(:resource_hash) { { resource: {} } }
+  let(:referrable_type) { Puppet::ResourceApi.register_type(name: 'minimal', attributes: {}) }
 
-  describe '#new(type_name, data_type, attribute_name, resource_hash)' do
+  describe '#new(type_name, data_type, attribute_name, resource_hash, referrable_type)' do
     it { expect { described_class.new(nil) }.to raise_error ArgumentError, %r{wrong number of arguments} }
-    it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash) }.not_to raise_error }
+    it { expect { described_class.new(type_name, data_type, attribute_name, resource_hash, referrable_type) }.not_to raise_error }
   end
 
   describe 'value munging and storage' do

--- a/spec/puppet/resource_api/read_only_parameter_spec.rb
+++ b/spec/puppet/resource_api/read_only_parameter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::ReadOnlyParameter do

--- a/spec/puppet/resource_api/simple_provider_spec.rb
+++ b/spec/puppet/resource_api/simple_provider_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'puppet/resource_api/simple_provider'
 

--- a/spec/puppet/resource_api/transport/wrapper_spec.rb
+++ b/spec/puppet/resource_api/transport/wrapper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'puppet/resource_api/transport/wrapper'
 require_relative '../../../fixtures/test_module/lib/puppet/transport/test_device'

--- a/spec/puppet/resource_api/transport_schema_def_spec.rb
+++ b/spec/puppet/resource_api/transport_schema_def_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::TransportSchemaDef do

--- a/spec/puppet/resource_api/transport_spec.rb
+++ b/spec/puppet/resource_api/transport_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::Transport do
@@ -309,13 +311,13 @@ RSpec.describe Puppet::ResourceApi::Transport do
           expect(context).to receive(:debug).with('Discarding bolt metaparameter: remote-reserved')
           expect(context).to receive(:info).with('Discarding superfluous bolt attribute: user')
           expect(context).to receive(:warning).with('Discarding unknown attribute: bar')
-          described_class.send :validate, 'validate', :"remote-transport" => 'validate',
-                                                      :host => 'host value',
-                                                      :foo => 'foo value',
-                                                      :user => 'superfluous bolt value',
-                                                      :query => 'metaparameter value',
-                                                      :"remote-reserved" => 'reserved value',
-                                                      :bar => 'unknown attribute'
+          described_class.send :validate, 'validate', 'remote-transport': 'validate',
+                                                      host: 'host value',
+                                                      foo: 'foo value',
+                                                      user: 'superfluous bolt value',
+                                                      query: 'metaparameter value',
+                                                      'remote-reserved': 'reserved value',
+                                                      bar: 'unknown attribute'
         end
       end
     end

--- a/spec/puppet/resource_api/type_definition_spec.rb
+++ b/spec/puppet/resource_api/type_definition_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::TypeDefinition do

--- a/spec/puppet/resource_api/type_definition_spec.rb
+++ b/spec/puppet/resource_api/type_definition_spec.rb
@@ -55,6 +55,87 @@ RSpec.describe Puppet::ResourceApi::TypeDefinition do
     end
   end
 
+  describe '#create_attribute_in' do
+    let(:puppet_type) { instance_double('Puppet::Type', 'example_type') }
+    let(:foo_options) do
+      {
+        type: 'String',
+        desc: 'Example description for foo',
+        default: 'bar',
+      }
+    end
+    let(:definition) { { name: 'example_type', attributes: { foo: foo_options } } }
+
+    context 'when creating a valid attribute' do
+      it 'creates a Puppet::Property object' do
+        expect(puppet_type).to receive(:send).with(:newproperty, :foo, parent: Puppet::ResourceApi::Property)
+        type.create_attribute_in(puppet_type, :foo, :newproperty, Puppet::ResourceApi::Property, foo_options)
+      end
+    end
+
+    context 'when creating an invalid attribute' do
+      it 'errors cleanly'
+    end
+  end
+
+  describe '#insyncable_attributes' do
+    context 'when the definition includes an insyncable attribute' do
+      let(:definition) { { name: 'insyncer', attributes: { name: { type: 'String' } } } }
+
+      it { expect(type.insyncable_attributes).to eq([:name]) }
+    end
+
+    context 'when the definition does not include an insyncable attribute' do
+      let(:definition) do
+        {
+          name: 'insyncer',
+          attributes: {
+            name: { type: 'String', behaviour: :namevar },
+            only_readable: { type: 'String', behaviour: :read_only },
+            only_settable: { type: 'String', behaviour: :parameter },
+            only_initable: { type: 'String', behaviour: :init_only },
+          },
+        }
+      end
+
+      it { expect(type.insyncable_attributes).to eq([]) }
+    end
+  end
+
+  describe '#initialize' do
+    context 'when the custom_insync feature is specified' do
+      context 'when the definition includes an insyncable attribute' do
+        let(:definition) { { name: 'insyncer', features: ['custom_insync'], attributes: { name: { type: 'String' } } } }
+
+        it { expect(type.attributes).to be_key(:name) }
+        it { expect(type.attributes).not_to be_key(:rsapi_custom_insync_trigger) }
+      end
+
+      context 'when the definition does not include an insyncable attribute' do
+        let(:definition) { { name: 'insyncer', features: ['custom_insync'], attributes: { name: { type: 'String', behaviour: :parameter } } } }
+
+        it { expect(type.attributes).to be_key(:name) }
+        it { expect(type.attributes).not_to be_key(:rsapi_custom_insync_trigger) }
+      end
+    end
+
+    context 'when the custom_insync feature is not specified' do
+      context 'when the definition includes an insyncable attribute' do
+        let(:definition) { { name: 'insyncer', attributes: { name: { type: 'String' } } } }
+
+        it { expect(type.attributes).to be_key(:name) }
+        it { expect(type.attributes).not_to be_key(:rsapi_custom_insync_trigger) }
+      end
+
+      context 'when the definition does not include an insyncable attribute' do
+        let(:definition) { { name: 'insyncer', attributes: { name: { type: 'String', behaviour: :parameter } } } }
+
+        it { expect(type.attributes).to be_key(:name) }
+        it { expect(type.attributes).not_to be_key(:rsapi_custom_insync_trigger) }
+      end
+    end
+  end
+
   describe '#attributes' do
     context 'when type has attributes' do
       it { expect(type.attributes).to be_key(:ensure) }

--- a/spec/puppet/resource_api/value_creator_spec.rb
+++ b/spec/puppet/resource_api/value_creator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi::ValueCreator do

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Puppet::ResourceApi do
@@ -1503,7 +1505,7 @@ RSpec.describe Puppet::ResourceApi do
         def canonicalize(_context, resources)
           resources.map do |resource|
             result = resource.dup
-            unless resource[:test_string] && resource[:test_string].start_with?('canon')
+            unless resource[:test_string]&.start_with?('canon')
               result[:test_string] = ['canon', resource[:test_string]].compact.join
             end
             result

--- a/spec/puppet/util/network_device/simple/device_spec.rb
+++ b/spec/puppet/util/network_device/simple/device_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'puppet/util/network_device/simple/device'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'rspec-puppet'
 require 'open3'


### PR DESCRIPTION
This PR defines a custom `insync?` method for properties of a Resource API Type; this method can *only* be added to properties, not parameters, and is only called for properties which are not namevars.

Currently, it does a few things:

1. Add `custom_insync` to the list of valid type features
2. Ensure that if the `custom_insync` feature is specified all properties **except** the `ensure` property get the custom `insync?`, which calls into the provider before supering back to the property `insync?` method as defined by Puppet. `ensure` is already using a custom `insync?`, which this PR leaves alone.
3. Passes (some) information about the type and current context to the property so that the provider is available to be called from the new `insync?` method and context can be accessed from that method in the provider.

What this currently enables:

- A developer can now specify the `custom_insync` feature for a type and an `insync?` method in their provider; that method can know the attribute being checked, the `is` and `should` values of the *resource*, & the current context. If nothing is specified in this method, the comparison defaults to what Puppet currently uses; the same is true for any properties not especially handled inside of this method. Any comparison that returns `nil` will be supered back to the existing `insync?` method defined in `Puppet::Property`.