### PR TITLE
Only ship needed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.gem
 
 # rspec failure tracking
 .rspec_status

--- a/puppet-resource_api.gemspec
+++ b/puppet-resource_api.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
                          `git ls-files -z`.split("\x0")
                        else
                          Dir.glob('**/*')
-                       end.reject do |f|
-                         f.match(%r{^(test|spec|features)/})
+                       end.select do |f|
+                         f.match(%r{^(lib|docs|(CHANGELOG|CONTRIBUTING|README)\.md|LICENSE|NOTICE|puppet-resource_api\.gemspec)})
                        end
 
   spec.bindir        = 'exe'


### PR DESCRIPTION
Prior to this a lot of files that are only needed for CI were shipped. Arguably, the test suite should actually be shipped, but it wasn't previously anyway.

Found while creating an RPM package for this.

I'll admit I haven't tested the integration and please carefully verify if I haven't missed anything.