### PR TITLE
Support ensure parameter with Optional data type

### DIFF
--- a/lib/puppet/resource_api/simple_provider.rb
+++ b/lib/puppet/resource_api/simple_provider.rb
@@ -40,13 +40,13 @@ module Puppet::ResourceApi
           context.creating(name) do
             create(context, name_hash, should)
           end
-        elsif is[:ensure].to_s == 'present' && should[:ensure].to_s == 'present'
-          context.updating(name) do
-            update(context, name_hash, should)
-          end
         elsif is[:ensure].to_s == 'present' && should[:ensure].to_s == 'absent'
           context.deleting(name) do
             delete(context, name_hash)
+          end
+        elsif is[:ensure].to_s == 'present'
+          context.updating(name) do
+            update(context, name_hash, should)
           end
         end
       end

--- a/spec/acceptance/optional_ensure_spec.rb
+++ b/spec/acceptance/optional_ensure_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tempfile'
+require 'open3'
+
+RSpec.describe 'a type with optional ensure' do
+  # these common_args *have* to use debug to see the messages we are matching
+  let(:common_args) { '--verbose --trace --strict=error --modulepath spec/fixtures --debug' }
+
+  describe 'using `puppet apply`' do
+    it 'creates an absent resource when ensure => present is specified' do
+      stdout_str, _status = Open3.capture2e("puppet apply #{common_args} -e \"test_optional_ensure { newres: ensure => present, prop => 'myprop' }\"")
+      expect(stdout_str).to match %r{Creating: Creating 'newres' with}
+    end
+
+    it 'deletes an existing resource when ensure => absent is specified' do
+      stdout_str, _status = Open3.capture2e("puppet apply #{common_args} -e \"test_optional_ensure { existing: ensure => absent }\"")
+      expect(stdout_str).to match %r{Deleting: Deleting 'existing'}
+    end
+
+    it 'does nothing when an unknown resource is referenced with no ensure' do
+      stdout_str, _status = Open3.capture2e("puppet apply #{common_args} -e \"test_optional_ensure { missing: }\"")
+      expect(stdout_str).to match %r{Test_optional_ensure\[missing\]: Nothing to manage: }
+      expect(stdout_str).not_to match %r{Creating: }
+      expect(stdout_str).not_to match %r{Updating: }
+      expect(stdout_str).not_to match %r{Deleting: }
+    end
+
+    it 'does nothing when an existing resource is referenced with no ensure and no properties' do
+      stdout_str, _status = Open3.capture2e("puppet apply #{common_args} -e \"test_optional_ensure { existing: }\"")
+      expect(stdout_str).to match %r{Current State: \{:namevar=>"existing"}
+      expect(stdout_str).not_to match %r{Creating: }
+      expect(stdout_str).not_to match %r{Updating: }
+      expect(stdout_str).not_to match %r{Deleting: }
+    end
+
+    it 'updates changed properties when an existing resource is referenced with no ensure' do
+      stdout_str, _status = Open3.capture2e("puppet apply #{common_args} -e \"test_optional_ensure { existing: prop => 'asdf' }\"")
+      expect(stdout_str).to match %r{Updating: Updating 'existing' with}
+      expect(stdout_str).not_to match %r{Creating: }
+      expect(stdout_str).not_to match %r{Deleting: }
+    end
+  end
+end

--- a/spec/fixtures/test_module/lib/puppet/provider/test_optional_ensure/test_optional_ensure.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/test_optional_ensure/test_optional_ensure.rb
@@ -1,0 +1,27 @@
+require 'puppet/resource_api'
+require 'puppet/resource_api/simple_provider'
+
+# Implementation for the test_optional_ensure type using the Resource API.
+class Puppet::Provider::TestOptionalEnsure::TestOptionalEnsure < Puppet::ResourceApi::SimpleProvider
+  def get(_context)
+    [
+      {
+        namevar: 'existing',
+        ensure: 'present',
+        prop: 'my property',
+      },
+    ]
+  end
+
+  def create(context, name, should)
+    context.notice("Creating '#{name}' with #{should.inspect}")
+  end
+
+  def update(context, name, should)
+    context.notice("Updating '#{name}' with #{should.inspect}")
+  end
+
+  def delete(context, name)
+    context.notice("Deleting '#{name}'")
+  end
+end

--- a/spec/fixtures/test_module/lib/puppet/type/test_optional_ensure.rb
+++ b/spec/fixtures/test_module/lib/puppet/type/test_optional_ensure.rb
@@ -1,0 +1,24 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'test_optional_ensure',
+  docs: <<-EOS,
+      This type provides Puppet with the capabilities to manage ...
+    EOS
+  features: [],
+  attributes:   {
+    ensure:      {
+      type:    'Optional[Enum[present, absent]]',
+      desc:    'Whether this resource should be present or absent on the target system.',
+    },
+    namevar:        {
+      type:      'String',
+      desc:      'The name of the resource you want to manage.',
+      behaviour: :namevar,
+    },
+    prop: {
+      type: 'String',
+      desc: 'A property',
+    }
+  },
+)

--- a/spec/puppet/resource_api/simple_provider_spec.rb
+++ b/spec/puppet/resource_api/simple_provider_spec.rb
@@ -129,6 +129,38 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
     end
   end
 
+  context 'with a single change to update a resource with an optional ensure' do
+    let(:is_values) { { name: 'title', ensure: 'present', prop: 'a' } }
+    let(:should_values) { { name: 'title', prop: 'b' } }
+    let(:changes) do
+      { 'title' =>
+        {
+          is: is_values,
+          should: should_values,
+        } }
+    end
+
+    before(:each) do
+      allow(context).to receive(:updating).with('title').and_yield
+      allow(context).to receive(:type).and_return(type_def)
+      allow(type_def).to receive(:feature?).with('simple_get_filter')
+      allow(type_def).to receive(:namevars).and_return([:name])
+    end
+
+    it 'does not call create' do
+      expect(provider).to receive(:create).never
+      provider.set(context, changes)
+    end
+    it 'calls update once' do
+      expect(provider).to receive(:update).with(context, 'title', should_values).once
+      provider.set(context, changes)
+    end
+    it 'does not call delete' do
+      expect(provider).to receive(:delete).never
+      provider.set(context, changes)
+    end
+  end
+
   context 'with a single change to delete a resource' do
     let(:is_values) { { name: 'title', ensure: 'present' } }
     let(:should_values) { { name: 'title', ensure: 'absent' } }

--- a/spec/puppet/resource_api/type_definition_spec.rb
+++ b/spec/puppet/resource_api/type_definition_spec.rb
@@ -35,6 +35,20 @@ RSpec.describe Puppet::ResourceApi::TypeDefinition do
       it { expect(type.attributes).to be_key(:ensure) }
     end
 
+    context 'when type is ensurable with an optional ensure specified with Optional' do
+      let(:definition) { { name: 'ensurable', attributes: { ensure: { type: 'Optional[Enum[absent, present]]' } } } }
+
+      it { expect(type).to be_ensurable }
+      it { expect(type.attributes).to be_key(:ensure) }
+    end
+
+    context 'when type is ensurable with an optional ensure specified with Variant' do
+      let(:definition) { { name: 'ensurable', attributes: { ensure: { type: 'Variant[Enum[absent, present], Undef]' } } } }
+
+      it { expect(type).to be_ensurable }
+      it { expect(type.attributes).to be_key(:ensure) }
+    end
+
     context 'when type is not ensurable' do
       let(:definition) { { name: 'ensurable', attributes: { name: { type: 'String' } } } }
 


### PR DESCRIPTION
Add support for specifying the ensure parameter as an
Optional Enum data type.

This permits resource properties of types specified this way
to be managed but only if the resource is already present and
cleanly skipped otherwise.

This is a behavior already present in many traditional Puppet
resource types and this extends the option to the Resource API,
easing transition of existing resource types to the Resource API.