### PR TITLE
(GH-231) Add default to transport attributes

### DIFF
--- a/lib/puppet/resource_api/transport.rb
+++ b/lib/puppet/resource_api/transport.rb
@@ -103,6 +103,7 @@ module Puppet::ResourceApi::Transport
       clean_bolt_attributes(transport_schema, connection_info)
     end
 
+    apply_defaults(transport_schema, connection_info)
     message_prefix = 'The connection info provided does not match the Transport Schema'
     transport_schema.check_schema(connection_info, message_prefix)
     transport_schema.validate(connection_info)
@@ -127,6 +128,18 @@ module Puppet::ResourceApi::Transport
     connection_info
   end
   private_class_method :wrap_sensitive
+
+  def self.apply_defaults(transport_schema, connection_info)
+    context = get_context(transport_schema.name)
+    transport_schema.attributes.each do |attr_name, options|
+      if options.key?(:default) && connection_info.key?(attr_name) == false
+        context.debug('Using default value for attribute: %{attribute_name}, value: %{default_value}' % { attribute_name: attr_name, default_value: options[:default].inspect })
+        connection_info[attr_name] = options[:default]
+      end
+    end
+    connection_info
+  end
+  private_class_method :apply_defaults
 
   def self.transports
     @transports ||= {}

--- a/spec/acceptance/transport/transport_defaults_spec.rb
+++ b/spec/acceptance/transport/transport_defaults_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tempfile'
+require 'open3'
+
+RSpec.describe 'a transport' do
+  let(:common_args) { '--verbose --trace --debug --strict=error --modulepath spec/fixtures' }
+
+  before(:all) do
+    FileUtils.mkdir_p(File.expand_path('~/.puppetlabs/opt/puppet/cache/devices/the_node/state'))
+  end
+
+  describe 'using `puppet device`' do
+    let(:common_args) { super() + ' --target the_node' }
+    let(:device_conf) { Tempfile.new('device.conf') }
+    let(:device_conf_content) do
+      <<DEVICE_CONF
+[the_node]
+type test_device_default
+url  file://#{device_credentials.path}
+DEVICE_CONF
+    end
+    let(:device_credentials) { Tempfile.new('credentials.txt') }
+
+    def is_device_apply_supported?
+      Gem::Version.new(Puppet::PUPPETVERSION) >= Gem::Version.new('5.3.6') && Gem::Version.new(Puppet::PUPPETVERSION) != Gem::Version.new('5.4.0')
+    end
+
+    before(:each) do
+      skip "No device --apply in puppet before v5.3.6 nor in v5.4.0 (v#{Puppet::PUPPETVERSION} is installed)" unless is_device_apply_supported?
+      device_conf.write(device_conf_content)
+      device_conf.close
+
+      device_credentials.write(device_credentials_content)
+      device_credentials.close
+    end
+
+    after(:each) do
+      device_conf.unlink
+      device_credentials.unlink
+    end
+
+    context 'when all values are supplied' do
+      let(:device_credentials_content) do
+        <<DEVICE_CREDS
+{
+  username: foo
+  default_string: other
+  optional_default: bar
+  array_default: [z]
+}
+DEVICE_CREDS
+      end
+
+      it 'does not use default values' do
+        Tempfile.create('apply_success') do |f|
+          f.write 'notify { "foo": }'
+          f.close
+
+          stdout_str, status = Open3.capture2e("puppet device #{common_args} --deviceconfig #{device_conf.path}  --apply #{f.path}")
+          expect(status.exitstatus).to eq 0
+          expect(stdout_str).not_to match %r{Value type mismatch}
+          expect(stdout_str).not_to match %r{Error}
+
+          expect(stdout_str).to match %r{transport connection_info:}
+          expect(stdout_str).to match %r{:username=>"foo"}
+          expect(stdout_str).to match %r{:default_string=>"other"}
+          expect(stdout_str).to match %r{:optional_default=>"bar"}
+          expect(stdout_str).to match %r{:array_default=>\["z"\]}
+        end
+      end
+    end
+
+    context 'when no values supplied for parameters with defaults' do
+      let(:device_credentials_content) do
+        <<DEVICE_CREDS
+{
+  username: foo
+}
+DEVICE_CREDS
+      end
+
+      it 'uses the defaults specified' do
+        Tempfile.create('apply_success') do |f|
+          f.write 'notify { "foo": }'
+          f.close
+
+          stdout_str, status = Open3.capture2e("puppet device #{common_args} --deviceconfig #{device_conf.path}  --apply #{f.path}")
+          expect(stdout_str).not_to match %r{Value type mismatch}
+          expect(stdout_str).not_to match %r{Error}
+
+          expect(stdout_str).to match %r{Debug: test_device_default: Using default value for attribute: default_string, value: "default_value"}
+          expect(stdout_str).to match %r{Debug: test_device_default: Using default value for attribute: optional_default, value: "another_default_value"}
+          expect(stdout_str).to match %r{Debug: test_device_default: Using default value for attribute: array_default, value: \["a", "b"\]}
+          expect(stdout_str).to match %r{transport connection_info:}
+          expect(stdout_str).to match %r{:username=>"foo"}
+          expect(stdout_str).to match %r{:default_string=>"default_value"}
+          expect(stdout_str).to match %r{:optional_default=>"another_default_value"}
+          expect(stdout_str).to match %r{:array_default=>\["a", "b"\]}
+
+          expect(status.exitstatus).to eq 0
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/test_module/lib/puppet/transport/schema/test_device_default.rb
+++ b/spec/fixtures/test_module/lib/puppet/transport/schema/test_device_default.rb
@@ -1,0 +1,27 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_transport(
+  name: 'test_device_default', # points at class Puppet::Transport::TestDeviceDefault
+  desc: 'Connects to a device',
+  connection_info: {
+    username:        {
+      type:      'String',
+      desc:      'The name of the resource you want to manage.',
+    },
+    default_string: {
+      type:      'String',
+      desc:      'A string with a default.',
+      default:   'default_value',
+    },
+    optional_default: {
+      type:      'Optional[String]',
+      desc:      'An optional string with a default.',
+      default:   'another_default_value',
+    },
+    array_default: {
+      type:      'Optional[Array[String]]',
+      desc:      'An array of defaults.',
+      default:   ['a', 'b']
+    },
+  },
+)

--- a/spec/fixtures/test_module/lib/puppet/transport/test_device_default.rb
+++ b/spec/fixtures/test_module/lib/puppet/transport/test_device_default.rb
@@ -1,0 +1,21 @@
+module Puppet::Transport
+# a transport for a test_device
+class TestDeviceDefault
+  def initialize(_context, connection_info);
+    puts  "transport connection_info: #{connection_info}"
+  end
+
+  def facts(_context)
+    { 'foo' => 'bar' }
+  end
+
+  def verify(_context)
+    return true
+  end
+
+  def close(_context)
+    return
+  end
+end
+
+end

--- a/spec/fixtures/test_module/lib/puppet/util/network_device/test_device_default/device.rb
+++ b/spec/fixtures/test_module/lib/puppet/util/network_device/test_device_default/device.rb
@@ -1,0 +1,12 @@
+require 'puppet/resource_api/transport/wrapper'
+
+class Puppet::Util::NetworkDevice; end
+
+module Puppet::Util::NetworkDevice::Test_device_default # rubocop:disable Style/ClassAndModuleCamelCase
+  # The main class for handling the connection and command parsing to the IOS Catalyst device
+  class Device < Puppet::ResourceApi::Transport::Wrapper
+    def initialize(url_or_config, _options = {})
+      super('test_device_default', url_or_config)
+    end
+  end
+end

--- a/spec/integration/resource_api/transport_spec.rb
+++ b/spec/integration/resource_api/transport_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe 'Resource API Transport integration tests:' do
     it 'can be called twice' do
       expect(Puppet::ResourceApi::Transport.list).to be_empty
       Puppet::ResourceApi::Transport.list_all_transports('rp_env')
-      expect(Puppet::ResourceApi::Transport.list.length).to eq 2
+      expect(Puppet::ResourceApi::Transport.list.length).to eq 3
       Puppet::ResourceApi::Transport.list_all_transports('rp_env')
-      expect(Puppet::ResourceApi::Transport.list.length).to eq 2
+      expect(Puppet::ResourceApi::Transport.list.length).to eq 3
     end
   end
 end


### PR DESCRIPTION
Add the ability to specify a default to transport connection_info
attributes which will be used in the event no value for the given
connection_info attribute is provided.