### PR TITLE
(packaging) Sets version to 1.8.15 for release

### DIFF
--- a/lib/puppet/resource_api/version.rb
+++ b/lib/puppet/resource_api/version.rb
@@ -2,6 +2,6 @@
 
 module Puppet
   module ResourceApi
-    VERSION = '1.8.16'
+    VERSION = '1.8.15'
   end
 end


### PR DESCRIPTION
We need to release 1.8.15 for the upcoming Puppet 6.27.0 and 7.16.0 releases. [In this commit](https://github.com/puppetlabs/puppet-resource_api/commit/aebad5efd1107c068ab09e33634128efb5751892), our automation accidentally skipped 1.8.15 and went straight to 1.8.16.

After this is merged, I plan on running a package validation pipeline that will add the corresponding 1.8.15 tag.