### PR TITLE
Release 1.8.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,24 @@
 All significant changes to this repo will be summarized in this file.
 
 
-## [v1.8.14](https://github.com/puppetlabs/puppet-resource_api/tree/v1.8.14) (2021-06-09)
+## [1.8.15](https://github.com/puppetlabs/puppet-resource_api/tree/1.8.15) (2022-10-03)
 
-[Full Changelog](https://github.com/puppetlabs/puppet-resource_api/compare/1.8.13...v1.8.14)
+[Full Changelog](https://github.com/puppetlabs/puppet-resource_api/compare/1.8.14...1.8.15)
+
+**Merged pull requests:**
+
+- \(PA-4558\) Replaces Travis CI with GitHub Actions [\#298](https://github.com/puppetlabs/puppet-resource_api/pull/298) ([mhashizume](https://github.com/mhashizume))
+- Add snyk monitoring [\#297](https://github.com/puppetlabs/puppet-resource_api/pull/297) ([joshcooper](https://github.com/joshcooper))
+- \(packaging\) Sets version to 1.8.15 for release [\#296](https://github.com/puppetlabs/puppet-resource_api/pull/296) ([mhashizume](https://github.com/mhashizume))
+- Update CODEOWNERS [\#295](https://github.com/puppetlabs/puppet-resource_api/pull/295) ([binford2k](https://github.com/binford2k))
+- Add array support to autorequire variable expansion [\#294](https://github.com/puppetlabs/puppet-resource_api/pull/294) ([seanmil](https://github.com/seanmil))
+- \(GH-231\) Add default to transport attributes [\#293](https://github.com/puppetlabs/puppet-resource_api/pull/293) ([seanmil](https://github.com/seanmil))
+- Support ensure parameter with Optional data type [\#292](https://github.com/puppetlabs/puppet-resource_api/pull/292) ([seanmil](https://github.com/seanmil))
+- Only ship needed files [\#289](https://github.com/puppetlabs/puppet-resource_api/pull/289) ([ekohl](https://github.com/ekohl))
+
+## [1.8.14](https://github.com/puppetlabs/puppet-resource_api/tree/1.8.14) (2021-06-09)
+
+[Full Changelog](https://github.com/puppetlabs/puppet-resource_api/compare/1.8.13...1.8.14)
 
 **Implemented enhancements:**
 
@@ -32,7 +47,7 @@ All significant changes to this repo will be summarized in this file.
 - Language correction [\#270](https://github.com/puppetlabs/puppet-resource_api/pull/270) ([epackorigan](https://github.com/epackorigan))
 - \(maint\) Update CHANGELOG [\#268](https://github.com/puppetlabs/puppet-resource_api/pull/268) ([DavidS](https://github.com/DavidS))
 - \(maint\) update test matrix for current supported versions; remove older versions to cut down on resource usage [\#265](https://github.com/puppetlabs/puppet-resource_api/pull/265) ([DavidS](https://github.com/DavidS))
-- \(maint\) Mock Hocon.load\(...\) [\#263](https://github.com/puppetlabs/puppet-resource_api/pull/263) ([IrimieBogdan](https://github.com/IrimieBogdan))
+- \(maint\) Mock Hocon.load\(...\) [\#263](https://github.com/puppetlabs/puppet-resource_api/pull/263) ([BogdanIrimie](https://github.com/BogdanIrimie))
 - Update rake requirement from ~\> 10.0 to ~\> 13.0 [\#262](https://github.com/puppetlabs/puppet-resource_api/pull/262) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
 - \(maint\) update Gemfile to allow use of non-vulnerable rake version 12.3.3 [\#260](https://github.com/puppetlabs/puppet-resource_api/pull/260) ([DavidS](https://github.com/DavidS))
 

--- a/Rakefile
+++ b/Rakefile
@@ -51,12 +51,13 @@ begin
   require 'github_changelog_generator/task'
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     require 'puppet/resource_api/version'
-    config.future_release = "v#{Puppet::ResourceApi::VERSION}"
+    config.future_release = "#{Puppet::ResourceApi::VERSION}"
     config.header = "# Changelog\n\n" \
       "All significant changes to this repo will be summarized in this file.\n"
     # config.include_labels = %w[enhancement bug]
     config.user = 'puppetlabs'
     config.project = 'puppet-resource_api'
+    config.exclude_tags = ['v1.8.14']
   end
 rescue LoadError
   desc 'Install github_changelog_generator to get access to automatic changelog generation'


### PR DESCRIPTION
This repo historically used v1.x.x tags, but we stopped tagging with the `v`
prefix in 1.8.2. However, when doing the 1.8.14 release, both 1.8.14 and v1.8.14
tags were created. So this commit excludes the v1.8.14 tag to avoid creating an
empty changelog diff for `v1.8.14...1.8.14`

And it updates the Rakefile to not prefix the future tag with `v`.

Our puppet-agent automation handles tag & bumps for components and doesn't use `v` prefixes, so it's better that resource-api doesn't either.

Also note we [planned on releasing 1.8.15 in 6.27.0 and 7.16.0](2bfa046993305de71901fa55c714b9780501c6c6) but we ended up not doing that:
https://github.com/puppetlabs/puppet-agent/blob/6.27.0/configs/components/puppet-resource_api.json#L1
https://github.com/puppetlabs/puppet-agent/blob/7.16.0/configs/components/puppet-resource_api.json#L1

so we can tag the HEAD of the repo as 1.8.15