### PR TITLE
Update for release 1.8.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 All significant changes to this repo will be summarized in this file.
 
 
-## [1.8.15](https://github.com/puppetlabs/puppet-resource_api/tree/1.8.15) (2022-10-03)
+## [1.8.16](https://github.com/puppetlabs/puppet-resource_api/tree/1.8.16) (2022-10-03)
 
-[Full Changelog](https://github.com/puppetlabs/puppet-resource_api/compare/1.8.14...1.8.15)
+[Full Changelog](https://github.com/puppetlabs/puppet-resource_api/compare/1.8.14...1.8.16)
 
 **Merged pull requests:**
 

--- a/Rakefile
+++ b/Rakefile
@@ -55,6 +55,7 @@ begin
     config.header = "# Changelog\n\n" \
       "All significant changes to this repo will be summarized in this file.\n"
     # config.include_labels = %w[enhancement bug]
+    config.exclude_labels = %w{duplicate question invalid wontfix wont-fix skip-changelog}
     config.user = 'puppetlabs'
     config.project = 'puppet-resource_api'
     config.exclude_tags = ['v1.8.14']

--- a/lib/puppet/resource_api/version.rb
+++ b/lib/puppet/resource_api/version.rb
@@ -2,6 +2,6 @@
 
 module Puppet
   module ResourceApi
-    VERSION = '1.8.15'
+    VERSION = '1.8.16'
   end
 end


### PR DESCRIPTION
We have to burn 1.8.15 since our automation won't allow bumping to a version
string (1.8.16) that has already been bumped to. See https://github.com/puppetlabs/puppet-resource_api/commit/aebad5efd1107c068ab09e33634128efb5751892. So during
the next release, we will release 1.8.16 and bump to 1.8.17.