### PR TITLE
(packaging) Bump to version '1.8.17' [no-promote]

### DIFF
--- a/lib/puppet/resource_api/version.rb
+++ b/lib/puppet/resource_api/version.rb
@@ -2,6 +2,6 @@
 
 module Puppet
   module ResourceApi
-    VERSION = '1.8.16'
+    VERSION = '1.8.17'
   end
 end


### PR DESCRIPTION
User error in release automation meant this bump did not happen; manually bumping here.