### PR TITLE
SimpleProvider name fixes

### DIFF
--- a/lib/puppet/resource_api/simple_provider.rb
+++ b/lib/puppet/resource_api/simple_provider.rb
@@ -6,8 +6,8 @@ module Puppet::ResourceApi
   # This class provides a default implementation for set(), when your resource does not benefit from batching.
   # Instead of processing changes yourself, the `create`, `update`, and `delete` functions, are called for you,
   # with proper logging already set up.
-  # Note that your type needs to use `name` as its namevar, and `ensure` in the conventional way to signal presence
-  # and absence of resources.
+  # Note that your type needs to use `ensure` in the conventional way with values of `prsesent`
+  # and `absent` to signal presence and absence of resources.
   class SimpleProvider
     def set(context, changes)
       namevars = context.type.namevars

--- a/lib/puppet/resource_api/simple_provider.rb
+++ b/lib/puppet/resource_api/simple_provider.rb
@@ -24,8 +24,8 @@ module Puppet::ResourceApi
 
         raise 'SimpleProvider cannot be used with a Type that is not ensurable' unless context.type.ensurable?
 
-        is = SimpleProvider.create_absent(:name, name) if is.nil?
-        should = SimpleProvider.create_absent(:name, name) if should.nil?
+        is_ensure = is.nil? ? 'absent' : is[:ensure].to_s
+        should_ensure = should.nil? ? 'absent' : should[:ensure].to_s
 
         name_hash = if namevars.length > 1
                       # pass a name_hash containing the values of all namevars
@@ -38,15 +38,15 @@ module Puppet::ResourceApi
                       name
                     end
 
-        if is[:ensure].to_s == 'absent' && should[:ensure].to_s == 'present'
+        if is_ensure == 'absent' && should_ensure == 'present'
           context.creating(name) do
             create(context, name_hash, should)
           end
-        elsif is[:ensure].to_s == 'present' && should[:ensure].to_s == 'absent'
+        elsif is_ensure == 'present' && should_ensure == 'absent'
           context.deleting(name) do
             delete(context, name_hash)
           end
-        elsif is[:ensure].to_s == 'present'
+        elsif is_ensure == 'present'
           context.updating(name) do
             update(context, name_hash, should)
           end
@@ -64,17 +64,6 @@ module Puppet::ResourceApi
 
     def delete(_context, _name)
       raise "#{self.class} has not implemented `delete`"
-    end
-
-    # @api private
-    def self.create_absent(namevar, title)
-      result = if title.is_a? Hash
-                 title.dup
-               else
-                 { namevar => title }
-               end
-      result[:ensure] = 'absent'
-      result
     end
 
     # @api private

--- a/spec/puppet/resource_api/simple_provider_spec.rb
+++ b/spec/puppet/resource_api/simple_provider_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
   context 'with no changes' do
     let(:changes) { {} }
 
+    before(:each) do
+      allow(type_def).to receive(:namevars)
+    end
+
     it 'does not call create' do
       expect(provider).to receive(:create).never
       provider.set(context, changes)
@@ -362,6 +366,7 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
       allow(context).to receive(:updating).with('title').and_yield
       allow(type_def).to receive(:feature?).with('simple_get_filter')
       allow(type_def).to receive(:ensurable?).and_return(false)
+      allow(type_def).to receive(:namevars).and_return([:name])
     end
 
     it { expect { provider.set(context, changes) }.to raise_error %r{SimpleProvider cannot be used with a Type that is not ensurable} }

--- a/spec/puppet/resource_api/simple_provider_spec.rb
+++ b/spec/puppet/resource_api/simple_provider_spec.rb
@@ -143,6 +143,20 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
       expect(type_def).to receive(:check_schema).never
       provider.set(context, changes)
     end
+
+    context 'when the namevar is not name' do
+      let(:is_values) { { key: 'title', ensure: 'present' } }
+      let(:should_values) { { key: 'title', ensure: 'present' } }
+
+      before(:each) do
+        allow(type_def).to receive(:namevars).and_return([:key])
+      end
+
+      it 'calls update once' do
+        expect(provider).to receive(:update).with(context, 'title', should_values).once
+        provider.set(context, changes)
+      end
+    end
   end
 
   context 'with a single change to update a resource without :is supplied' do
@@ -193,6 +207,20 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
 
       it 'calls `get` with name' do
         expect(provider).to receive(:get).with(context, ['title'])
+        provider.set(context, changes)
+      end
+    end
+
+    context 'when the namevar is not name' do
+      let(:is_values) { [{ key: 'title', ensure: 'present' }] }
+      let(:should_values) { { key: 'title', ensure: 'present' } }
+
+      before(:each) do
+        allow(type_def).to receive(:namevars).and_return([:key])
+      end
+
+      it 'calls update once' do
+        expect(provider).to receive(:update).with(context, 'title', should_values).once
         provider.set(context, changes)
       end
     end
@@ -263,6 +291,20 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
       expect(provider).to receive(:get).never
       provider.set(context, changes)
     end
+
+    context 'when the namevar is not name' do
+      let(:is_values) { { key: 'title', ensure: 'present' } }
+      let(:should_values) { { key: 'title', ensure: 'absent' } }
+
+      before(:each) do
+        allow(type_def).to receive(:namevars).and_return([:key])
+      end
+
+      it 'calls delete once' do
+        expect(provider).to receive(:delete).with(context, 'title').once
+        provider.set(context, changes)
+      end
+    end
   end
 
   context 'with a single change to delete a resource without :is supplied' do
@@ -311,6 +353,20 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
 
       it 'calls `get` with name' do
         expect(provider).to receive(:get).with(context, ['title'])
+        provider.set(context, changes)
+      end
+    end
+
+    context 'when the namevar is not name' do
+      let(:is_values) { [{ key: 'title', ensure: 'present' }] }
+      let(:should_values) { { key: 'title', ensure: 'absent' } }
+
+      before(:each) do
+        allow(type_def).to receive(:namevars).and_return([:key])
+      end
+
+      it 'calls delete once' do
+        expect(provider).to receive(:delete).with(context, 'title').once
         provider.set(context, changes)
       end
     end

--- a/spec/puppet/resource_api/simple_provider_spec.rb
+++ b/spec/puppet/resource_api/simple_provider_spec.rb
@@ -83,6 +83,10 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
       expect(provider).to receive(:delete).never
       provider.set(context, changes)
     end
+    it 'calls get once' do
+      expect(provider).to receive(:get).once
+      provider.set(context, changes)
+    end
 
     context 'with a type that supports `simple_get_filter`' do
       before(:each) do
@@ -97,7 +101,7 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
     end
   end
 
-  context 'with a single change to update a resource' do
+  context 'with a single change to update a resource with :is supplied' do
     let(:is_values) { { name: 'title', ensure: 'present' } }
     let(:should_values) { { name: 'title', ensure: 'present' } }
     let(:changes) do
@@ -126,6 +130,67 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
     it 'does not call delete' do
       expect(provider).to receive(:delete).never
       provider.set(context, changes)
+    end
+    it 'does not call get' do
+      expect(provider).to receive(:get).never
+      provider.set(context, changes)
+    end
+    it 'does not check the schema' do
+      expect(type_def).to receive(:check_schema).never
+      provider.set(context, changes)
+    end
+  end
+
+  context 'with a single change to update a resource without :is supplied' do
+    let(:is_values) { [{ name: 'title', ensure: 'present' }] }
+    let(:should_values) { { name: 'title', ensure: 'present' } }
+    let(:changes) do
+      { 'title' =>
+        {
+          should: should_values,
+        } }
+    end
+
+    before(:each) do
+      allow(context).to receive(:updating).with('title').and_yield
+      allow(context).to receive(:type).and_return(type_def)
+      allow(type_def).to receive(:feature?).with('simple_get_filter')
+      allow(type_def).to receive(:check_schema)
+      allow(type_def).to receive(:namevars).and_return([:name])
+      allow(provider).to receive(:get).with(context).and_return(is_values)
+    end
+
+    it 'does not call create' do
+      expect(provider).to receive(:create).never
+      provider.set(context, changes)
+    end
+    it 'calls update once' do
+      expect(provider).to receive(:update).with(context, 'title', should_values).once
+      provider.set(context, changes)
+    end
+    it 'calls get once' do
+      expect(provider).to receive(:get).with(context).once
+      provider.set(context, changes)
+    end
+    it 'does not check the schema' do
+      expect(type_def).to receive(:check_schema).with(is_values.first)
+      provider.set(context, changes)
+    end
+    it 'does not call delete' do
+      expect(provider).to receive(:delete).never
+      provider.set(context, changes)
+    end
+
+    context 'with a type that supports `simple_get_filter`' do
+      before(:each) do
+        allow(type_def).to receive(:feature?).with('simple_get_filter').and_return(true)
+        allow(provider).to receive(:get).with(context, ['title']).and_return(is_values)
+      end
+
+      it 'calls `get` with name' do
+        expect(provider).to receive(:get).with(context, ['title'])
+        provider.set(context, changes)
+      end
     end
   end
 
@@ -161,7 +226,7 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
     end
   end
 
-  context 'with a single change to delete a resource' do
+  context 'with a single change to delete a resource with :is supplied' do
     let(:is_values) { { name: 'title', ensure: 'present' } }
     let(:should_values) { { name: 'title', ensure: 'absent' } }
     let(:changes) do
@@ -174,7 +239,6 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
 
     before(:each) do
       allow(context).to receive(:deleting).with('title').and_yield
-      allow(context).to receive(:type).and_return(type_def)
       allow(type_def).to receive(:feature?).with('simple_get_filter')
       allow(type_def).to receive(:namevars).and_return([:name])
     end
@@ -190,6 +254,61 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
     it 'calls delete once' do
       expect(provider).to receive(:delete).with(context, 'title').once
       provider.set(context, changes)
+    end
+    it 'does not call get' do
+      expect(provider).to receive(:get).never
+      provider.set(context, changes)
+    end
+  end
+
+  context 'with a single change to delete a resource without :is supplied' do
+    let(:is_values) { [{ name: 'title', ensure: 'present' }] }
+    let(:should_values) { { name: 'title', ensure: 'absent' } }
+    let(:changes) do
+      { 'title' =>
+        {
+          should: should_values,
+        } }
+    end
+
+    before(:each) do
+      allow(context).to receive(:deleting).with('title').and_yield
+      allow(type_def).to receive(:feature?).with('simple_get_filter')
+      allow(type_def).to receive(:check_schema)
+      allow(type_def).to receive(:namevars).and_return([:name])
+      allow(provider).to receive(:get).with(context).and_return(is_values)
+    end
+
+    it 'does not call create' do
+      expect(provider).to receive(:create).never
+      provider.set(context, changes)
+    end
+    it 'does not call update' do
+      expect(provider).to receive(:update).never
+      provider.set(context, changes)
+    end
+    it 'calls delete once' do
+      expect(provider).to receive(:delete).with(context, 'title').once
+      provider.set(context, changes)
+    end
+    it 'calls check_schema' do
+      expect(type_def).to receive(:check_schema).once
+      provider.set(context, changes)
+    end
+    it 'calls get once to retrieve "is"' do
+      expect(provider).to receive(:get).with(context).once
+      provider.set(context, changes)
+    end
+
+    context 'with a type that supports `simple_get_filter`' do
+      before(:each) do
+        allow(type_def).to receive(:feature?).with('simple_get_filter').and_return(true)
+      end
+
+      it 'calls `get` with name' do
+        expect(provider).to receive(:get).with(context, ['title'])
+        provider.set(context, changes)
+      end
     end
   end
 
@@ -248,27 +367,220 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
     it { expect { provider.set(context, changes) }.to raise_error %r{SimpleProvider cannot be used with a Type that is not ensurable} }
   end
 
-  context 'with changes from a composite namevar type' do
+  context 'with a single change to create a composite namevar resource' do
+    let(:should_values) { { name1: 'title1', name2: 'title2', ensure: 'present' } }
     let(:changes) do
       {
-        { name1: 'value1', name2: 'value2' } =>
+        { name1: 'title1', name2: 'title2' } =>
           {
-            should: { name1: 'value1', name2: 'value2', ensure: 'present' },
+            should: should_values,
           },
       }
     end
 
     before(:each) do
-      allow(context).to receive(:creating).with({ name1: 'value1', name2: 'value2' }).and_yield
+      allow(context).to receive(:creating).with({ name1: 'title1', name2: 'title2' }).and_yield
       allow(type_def).to receive(:feature?).with('simple_get_filter').and_return(true)
       allow(type_def).to receive(:namevars).and_return([:name1, :name2])
       allow(type_def).to receive(:check_schema)
     end
 
-    it 'calls the crud methods with the right title' do
-      expect(provider).to receive(:create).with(context, { name1: 'value1', name2: 'value2' }, hash_including(name1: 'value1'))
-
+    it 'calls create once' do
+      expect(provider).to receive(:create).with(context, { name1: 'title1', name2: 'title2' }, should_values).once
       provider.set(context, changes)
+    end
+    it 'does not call update' do
+      expect(provider).to receive(:update).never
+      provider.set(context, changes)
+    end
+    it 'does not call delete' do
+      expect(provider).to receive(:delete).never
+      provider.set(context, changes)
+    end
+
+    context 'with a type that supports `simple_get_filter`' do
+      before(:each) do
+        allow(type_def).to receive(:feature?).with('simple_get_filter').and_return(true)
+      end
+
+      it 'calls `get` with name' do
+        expect(provider).to receive(:get).with(context, [{ name1: 'title1', name2: 'title2' }])
+        provider.set(context, changes)
+      end
+    end
+  end
+
+  context 'with a single change to update a composite namevar resource with :is supplied' do
+    let(:is_values) { { name1: 'title1', name2: 'title2', ensure: 'present' } }
+    let(:should_values) { { name1: 'title1', name2: 'title2', ensure: 'present' } }
+    let(:changes) do
+      {
+        { name1: 'title1', name2: 'title2' } =>
+          {
+            is: is_values,
+            should: should_values,
+          },
+      }
+    end
+
+    before(:each) do
+      allow(context).to receive(:updating).with({ name1: 'title1', name2: 'title2' }).and_yield
+      allow(type_def).to receive(:feature?).with('simple_get_filter')
+      allow(type_def).to receive(:check_schema)
+      allow(type_def).to receive(:namevars).and_return([:name1, :name2])
+    end
+
+    it 'does not call create' do
+      expect(provider).to receive(:create).never
+      provider.set(context, changes)
+    end
+    it 'calls update once' do
+      expect(provider).to receive(:update).with(context, { name1: 'title1', name2: 'title2' }, should_values).once
+      provider.set(context, changes)
+    end
+    it 'does not call delete' do
+      expect(provider).to receive(:delete).never
+      provider.set(context, changes)
+    end
+    it 'does not call get' do
+      expect(provider).to receive(:get).never
+      provider.set(context, changes)
+    end
+  end
+
+  context 'with a single change to update a composite namevar resource without :is supplied' do
+    let(:is_values) { [{ name1: 'title1', name2: 'title2', ensure: 'present' }] }
+    let(:should_values) { { name1: 'title1', name2: 'title2', ensure: 'present' } }
+    let(:changes) do
+      {
+        { name1: 'title1', name2: 'title2' } =>
+          {
+            should: should_values,
+          },
+      }
+    end
+
+    before(:each) do
+      allow(context).to receive(:updating).with({ name1: 'title1', name2: 'title2' }).and_yield
+      allow(type_def).to receive(:feature?).with('simple_get_filter')
+      allow(type_def).to receive(:check_schema)
+      allow(type_def).to receive(:namevars).and_return([:name1, :name2])
+      allow(provider).to receive(:get).with(context).and_return(is_values)
+    end
+
+    it 'does not call create' do
+      expect(provider).to receive(:create).never
+      provider.set(context, changes)
+    end
+    it 'calls update once' do
+      expect(provider).to receive(:update).with(context, { name1: 'title1', name2: 'title2' }, should_values).once
+      provider.set(context, changes)
+    end
+    it 'does not call delete' do
+      expect(provider).to receive(:delete).never
+      provider.set(context, changes)
+    end
+    it 'calls get once' do
+      expect(provider).to receive(:get).once
+      provider.set(context, changes)
+    end
+
+    context 'with a type that supports `simple_get_filter`' do
+      before(:each) do
+        allow(type_def).to receive(:feature?).with('simple_get_filter').and_return(true)
+        allow(provider).to receive(:get).with(context, [{ name1: 'title1', name2: 'title2' }]).and_return(is_values)
+      end
+
+      it 'calls `get` with name' do
+        expect(provider).to receive(:get).with(context, [{ name1: 'title1', name2: 'title2' }]).once
+        provider.set(context, changes)
+      end
+    end
+  end
+
+  context 'with a single change to delete a composite namevar resource with :is supplied' do
+    let(:is_values) { { name1: 'title1', name2: 'title2', ensure: 'present' } }
+    let(:should_values) { { name1: 'title1', name2: 'title2', ensure: 'absent' } }
+    let(:changes) do
+      {
+        { name1: 'title1', name2: 'title2' } =>
+          {
+            is: is_values,
+            should: should_values,
+          },
+      }
+    end
+
+    before(:each) do
+      allow(context).to receive(:deleting).with({ name1: 'title1', name2: 'title2' }).and_yield
+      allow(type_def).to receive(:feature?).with('simple_get_filter')
+      allow(type_def).to receive(:namevars).and_return([:name1, :name2])
+    end
+
+    it 'does not call create' do
+      expect(provider).to receive(:create).never
+      provider.set(context, changes)
+    end
+    it 'does not call update' do
+      expect(provider).to receive(:update).never
+      provider.set(context, changes)
+    end
+    it 'calls delete once' do
+      expect(provider).to receive(:delete).with(context, { name1: 'title1', name2: 'title2' }).once
+      provider.set(context, changes)
+    end
+    it 'does not call get' do
+      expect(provider).to receive(:get).never
+      provider.set(context, changes)
+    end
+  end
+
+  context 'with a single change to delete a composite namevar resource without :is supplied' do
+    let(:is_values) { [{ name1: 'title1', name2: 'title2', ensure: 'present' }] }
+    let(:should_values) { { name1: 'title1', name2: 'title2', ensure: 'absent' } }
+    let(:changes) do
+      {
+        { name1: 'title1', name2: 'title2' } =>
+          {
+            should: should_values,
+          },
+      }
+    end
+
+    before(:each) do
+      allow(context).to receive(:deleting).with({ name1: 'title1', name2: 'title2' }).and_yield
+      allow(type_def).to receive(:feature?).with('simple_get_filter')
+      allow(type_def).to receive(:check_schema)
+      allow(type_def).to receive(:namevars).and_return([:name1, :name2])
+      allow(provider).to receive(:get).with(context).and_return(is_values)
+    end
+
+    it 'does not call create' do
+      expect(provider).to receive(:create).never
+      provider.set(context, changes)
+    end
+    it 'does not call update' do
+      expect(provider).to receive(:update).never
+      provider.set(context, changes)
+    end
+    it 'calls delete once' do
+      expect(provider).to receive(:delete).with(context, { name1: 'title1', name2: 'title2' }).once
+      provider.set(context, changes)
+    end
+    it 'calls get once' do
+      expect(provider).to receive(:get).once
+      provider.set(context, changes)
+    end
+
+    context 'with a type that supports `simple_get_filter`' do
+      before(:each) do
+        allow(type_def).to receive(:feature?).with('simple_get_filter').and_return(true)
+      end
+
+      it 'calls `get` with name' do
+        expect(provider).to receive(:get).with(context, [{ name1: 'title1', name2: 'title2' }])
+        provider.set(context, changes)
+      end
     end
   end
 end


### PR DESCRIPTION
The SimpleProvider has some support for composite namevars, but it is incomplete and only works in scenarios where the :is value is supplied. This PR adds more comprehensive unit tests which cover scenarios where :is is not passed and fixes these issues. As a bonus, the SimpleProvider now works for types with any namevar (it no longer is required to be `name` for the single-valued case).  Some additional code cleanups are included.