### PR TITLE
Fix instances method with simple_get_filter

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -248,7 +248,7 @@ module Puppet::ResourceApi
         provider(type_definition.name)
 
         initial_fetch = if type_definition.feature?('simple_get_filter')
-                          my_provider.get(context, [])
+                          my_provider.get(context, nil)
                         else
                           my_provider.get(context)
                         end

--- a/spec/acceptance/composite_namevar_spec.rb
+++ b/spec/acceptance/composite_namevar_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'a type with composite namevars' do
     it 'is returns the values correctly' do
       stdout_str, status = Open3.capture2e("puppet resource #{common_args} composite_namevar")
       expect(stdout_str.strip).to match %r{^composite_namevar}
-      expect(stdout_str.strip).to match %r{Looking for \[\]}
+      expect(stdout_str.strip).to match %r{Looking for nil}
       expect(status).to eq 0
     end
     it 'returns the required resource correctly' do
@@ -20,7 +20,7 @@ RSpec.describe 'a type with composite namevars' do
       expect(stdout_str.strip).to match %r{ensure\s*=> \'present\'}
       expect(stdout_str.strip).to match %r{package\s*=> \'php\'}
       expect(stdout_str.strip).to match %r{manager\s*=> \'yum\'}
-      expect(stdout_str.strip).to match %r{Looking for \[\]}
+      expect(stdout_str.strip).to match %r{Looking for nil}
       expect(status.exitstatus).to eq 0
     end
     it 'throws error if title is not a matching title_pattern' do

--- a/spec/fixtures/test_module/lib/puppet/provider/test_simple_get_filter/test_simple_get_filter.rb
+++ b/spec/fixtures/test_module/lib/puppet/provider/test_simple_get_filter/test_simple_get_filter.rb
@@ -4,9 +4,7 @@ require 'puppet/resource_api/simple_provider'
 # Implementation for the test_simple_get_filter type using the Resource API.
 class Puppet::Provider::TestSimpleGetFilter::TestSimpleGetFilter < Puppet::ResourceApi::SimpleProvider
   def get(_context, names = nil)
-    raise Puppet::DevError, 'names parameter must be provided to TestSimpleGetFilter#get()' if names.nil?
-
-    result = if names.empty?
+    result = if names.nil?
                # rather than fething everything from your large dataset, return a subset of the data that you are happy to show.
                # This will be cached by Puppet. If a resource requested exists in the cache, then no futher calls are made to the provider.
                [{

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -2196,7 +2196,7 @@ CODE
       end
 
       it 'passes through the an empty array to `get`' do
-        expect(provider).to receive(:get).with(anything, []).and_return([])
+        expect(provider).to receive(:get).with(anything, nil).and_return([])
         type.instances
       end
 


### PR DESCRIPTION
Per issue #303, the Puppet Specification for Resource API indicates that a provider get() method when simple_get_filter is enabled should return all instances when the second/names parameter is set to 'nil'.

Currently, if a Resource API provider is implemented per specification and uses the simple_get_filter feature it will never return any resources for the `instances()` method, which prevents things such a resource purging from working.