### PR TITLE
(CAT-761) Add custom_generate as a feature

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -136,6 +136,23 @@ module Puppet::ResourceApi
         @rsapi_canonicalized_target_state
       end
 
+      # Method is used to custom generate resources which are then applied by Puppet
+      def generate
+        # If feature `custom_generate` has been set then call the generate function within the provider and return the given results
+        return unless type_definition&.feature?('custom_generate')
+        should_hash = rsapi_canonicalized_target_state
+        is_hash     = rsapi_current_state
+        title       = rsapi_title
+
+        # Ensure that a custom `generate` method has been created within the provider
+        raise(Puppet::DevError, 'No generate method found within the types provider') unless my_provider.respond_to?(:generate)
+        # Call the providers custom `generate` method
+        rules_resources = my_provider.generate(context, title, is_hash, should_hash)
+
+        # Return array of resources
+        rules_resources
+      end
+
       def rsapi_current_state
         refresh_current_state unless @rsapi_current_state
         @rsapi_current_state

--- a/lib/puppet/resource_api/type_definition.rb
+++ b/lib/puppet/resource_api/type_definition.rb
@@ -36,7 +36,7 @@ module Puppet::ResourceApi
       Puppet::ResourceApi::DataTypeHandling.validate_ensure(definition)
 
       definition[:features] ||= []
-      supported_features = %w[supports_noop canonicalize custom_insync remote_resource simple_get_filter].freeze
+      supported_features = %w[supports_noop canonicalize custom_insync remote_resource simple_get_filter custom_generate].freeze
       unknown_features = definition[:features] - supported_features
       Puppet.warning("Unknown feature detected: #{unknown_features.inspect}") unless unknown_features.empty?
     end


### PR DESCRIPTION
Allows the generate function to be utilized in order to manually create an array of types to be enforced.
The `generate` method is called prior to the resource being managed.
There is a second `eval_generate` method that is called after it has been, which may be good to add at a later date.