### PR TITLE
(PA-5641) Update rspec tests with modern Ruby

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -11,26 +11,28 @@ permissions:
 
 jobs:
   rspec_tests:
-    name: RSpec (Ruby ${{ matrix.ruby }}, Puppet ${{ matrix.puppet_version }})
+    name: Puppet ${{ matrix.cfg.puppet_version }}, Ruby ${{ matrix.cfg.ruby }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.7', 'jruby-9.2.17.0' ]
-        puppet_version: [ '~> 6.29', '~> 7.22' ]
+        cfg:
+          - {puppet_version: '7', ruby: '2.7'}
+          - {puppet_version: '7', ruby: 'jruby-9.3.7.0'}
+          - {puppet_version: '8', ruby: '3.2'}
+          - {puppet_version: '8', ruby: 'jruby-9.4.2.0'}
     env:
-      PUPPET_GEM_VERSION: ${{ matrix.puppet_version }}
+      PUPPET_GEM_VERSION: ~> ${{ matrix.cfg.puppet_version }}
     steps:
       - name: Checkout current PR
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install Ruby version ${{ matrix.ruby }}
+      - name: Install Ruby version ${{ matrix.cfg.ruby }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: ${{ matrix.cfg.ruby }}
       - name: Update rubygems and install gems
         run: |
-          gem update --system 3.3.26 --silent --no-document
           bundle config set without development
           bundle install --jobs 4 --retry 3
       - run: bundle exec rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -121,10 +121,9 @@ Lint/NestedMethodDefinition:
 RSpec/MessageSpies:
   Enabled: false
 
-# If neighbouring parameters are both hashes, it helps to have braces round both.
+# This cop causes issues on our current version of Rubocop (0.57.2) and newer (>= 3.0) Rubies because of keyword arguments.
 Style/BracesAroundHashParameters:
-  Exclude:
-    - 'spec/puppet/resource_api/base_context_spec.rb'
+  Enabled: false
 
 # requires 2.3's squiggly HEREDOC support, which we can't use, yet
 # see http://www.virtuouscode.com/2016/01/06/about-the-ruby-squiggly-heredoc-syntax/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Puppet::ResourceApi [![TravisCI Build Status](https://travis-ci.org/puppetlabs/puppet-resource_api.svg?branch=main)](https://travis-ci.org/puppetlabs/puppet-resource_api) [![Appveyor Build status](https://ci.appveyor.com/api/projects/status/8o9s1ax0hs8lm5fd/branch/main?svg=true)](https://ci.appveyor.com/project/puppetlabs/puppet-resource-api/branch/main) [![codecov](https://codecov.io/gh/puppetlabs/puppet-resource_api/branch/main/graph/badge.svg)](https://codecov.io/gh/puppetlabs/puppet-resource_api)
+# Puppet::ResourceApi [![Appveyor Build status](https://ci.appveyor.com/api/projects/status/8o9s1ax0hs8lm5fd/branch/main?svg=true)](https://ci.appveyor.com/project/puppetlabs/puppet-resource-api/branch/main) [![codecov](https://codecov.io/gh/puppetlabs/puppet-resource_api/branch/main/graph/badge.svg)](https://codecov.io/gh/puppetlabs/puppet-resource_api)
 
-This is an implementation of the [Resource API specification](https://github.com/puppetlabs/puppet-specifications/blob/main/language/resource-api/README.md).
+This is an implementation of the [Resource API specification](https://github.com/puppetlabs/puppet-specifications/blob/master/language/resource-api/README.md).
 
 Find a working example of a new-style providers in the [Palo Alto Firewall module](https://github.com/puppetlabs/puppetlabs-panos/):
 * [Type](https://github.com/puppetlabs/puppetlabs-panos/blob/main/lib/puppet/type/panos_address.rb)
@@ -15,18 +15,18 @@ Find a working example of a new-style providers in the [Palo Alto Firewall modul
 * The [Resource API specs](https://github.com/puppetlabs/puppet-specifications/blob/master/language/resource-api/README.md) describes details of all the capabilities of this gem.
 * The [puppetlabs-hue module](https://github.com/puppetlabs/puppetlabs-hue) is a very simple example for using the Resource API for remote resources.
 * The [meraki module](https://github.com/meraki/puppet-module) is a full example for using the Resource API for remote resources.
-* This [Introduction to Testing Puppet Modules](https://www.netways.de/index.php?id=3445#c44135) talk describes rspec usage in more detail.
-* The [RSpec docs](https://relishapp.com/rspec) provide an overview of the capabilities of rspec.
+* This [Introduction to Testing Puppet Modules](https://www.youtube.com/watch?v=GgNrxLfoDF8) talk describes rspec usage in more detail.
+* The [RSpec docs](https://rspec.info/documentation/) provide an overview of the capabilities of rspec.
 * Read [betterspecs](http://www.betterspecs.org/) for general guidelines on what is considered good specs.
 
 
 ## Deployment
 
-The `puppet-resource_api` gem is part of the [Puppet 6 Platform](https://puppet.com/blog/introducing-puppet-6). With older versions of Puppet, you can use the [puppetlabs-resource_api module](https://forge.puppet.com/puppetlabs/resource_api) to install the gem on your servers and agents.
+The `puppet-resource_api` gem is part of Puppet from version 6 onward.
 
 
 ## Contributing
-We are always welcoming bug reports and pull requests on the Resource API, so that we can continue to improve it to the best of our ability. If you would like to contribute, [have a look at our GitHub](https://github.com/puppetlabs/puppet-resource_api) and the [Resource API Backlog](https://github.com/puppetlabs/puppet-resource_api/projects/1).
+We welcome bug reports and pull requests on the Resource API so that we can continue to improve it to the best of our ability. If you would like to contribute, [have a look at our GitHub](https://github.com/puppetlabs/puppet-resource_api) and the [Resource API Backlog](https://github.com/puppetlabs/puppet-resource_api/projects/1).
 
 
 ## Known Issues

--- a/lib/puppet/resource_api/base_context.rb
+++ b/lib/puppet/resource_api/base_context.rb
@@ -90,7 +90,7 @@ class Puppet::ResourceApi::BaseContext
     end
   end
 
-  def processing(title, is, should, message: 'Processing')
+  def processing(title, is, should, message = 'Processing')
     raise "#{__method__} only accepts a single resource title" if title.respond_to?(:each)
     start_time = Time.now
     setup_context(title, message)

--- a/lib/puppet/resource_api/data_type_handling.rb
+++ b/lib/puppet/resource_api/data_type_handling.rb
@@ -86,7 +86,7 @@ module Puppet::ResourceApi::DataTypeHandling
     when Puppet::Pops::Types::PIntegerType,
          Puppet::Pops::Types::PFloatType,
          Puppet::Pops::Types::PNumericType
-      if value =~ %r{^-?\d+$} || value =~ Puppet::Pops::Patterns::NUMERIC
+      if value.is_a?(String) && (value.match?(%r{^-?\d+$}) || value.match?(Puppet::Pops::Patterns::NUMERIC))
         value = Puppet::Pops::Utils.to_n(value)
       end
     when Puppet::Pops::Types::PEnumType,

--- a/spec/puppet/resource_api/base_context_spec.rb
+++ b/spec/puppet/resource_api/base_context_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe Puppet::ResourceApi::BaseContext do
 
   describe '#feature_support?' do
     it {
-      expect(Puppet::Util::Log).to receive(:create).with(level: :warning, source: 'Puppet', message: match(%r{context.feature_support\? is deprecated\. Please use context.type.feature\? instead\.}))
+      expect(Puppet::Util::Log).to receive(:create).with({ level: :warning, source: 'Puppet', message: start_with('context.feature_support? is deprecated. Please use context.type.feature? instead.') }) # rubocop:disable Metrics/LineLength
       context.feature_support?('anything')
     }
   end

--- a/spec/puppet/resource_api/base_context_spec.rb
+++ b/spec/puppet/resource_api/base_context_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe Puppet::ResourceApi::BaseContext do
 
   describe '#feature_support?' do
     it {
-      expect(Puppet::Util::Log).to receive(:create).with(level: :warning, source: 'Puppet', message: match(%r{context.feature_support\? is deprecated. Please use context.type.feature\? instead\.}))
+      expect(Puppet::Util::Log).to receive(:create).with(level: :warning, source: 'Puppet', message: match(%r{context.feature_support\? is deprecated\. Please use context.type.feature\? instead\.}))
       context.feature_support?('anything')
     }
   end

--- a/spec/puppet/resource_api/simple_provider_spec.rb
+++ b/spec/puppet/resource_api/simple_provider_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Puppet::ResourceApi::SimpleProvider do
     end
 
     before(:each) do
-      allow(context).to receive(:creating).with(name1: 'value1', name2: 'value2').and_yield
+      allow(context).to receive(:creating).with({ name1: 'value1', name2: 'value2' }).and_yield
       allow(type_def).to receive(:feature?).with('simple_get_filter').and_return(true)
       allow(type_def).to receive(:namevars).and_return([:name1, :name2])
       allow(type_def).to receive(:check_schema)

--- a/spec/puppet/resource_api/transport_spec.rb
+++ b/spec/puppet/resource_api/transport_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe Puppet::ResourceApi::Transport do
 
     context 'when the transport file does not exist' do
       it 'throws a LoadError' do
-        expect(described_class).to receive(:validate).with(name, host: 'example.com')
+        expect(described_class).to receive(:validate).with(name, { host: 'example.com' })
         expect { described_class.connect(name, host: 'example.com') }.to raise_error LoadError, %r{(no such file to load|cannot load such file) -- puppet/transport/test_target}
       end
     end
@@ -198,10 +198,10 @@ RSpec.describe Puppet::ResourceApi::Transport do
         it 'throws a NameError' do
           described_class.register(schema)
 
-          expect(described_class).to receive(:validate).with(name, host: 'example.com')
+          expect(described_class).to receive(:validate).with(name, { host: 'example.com' })
           expect(described_class).to receive(:require).with('puppet/transport/test_target')
-          expect { described_class.connect(name, host: 'example.com') }.to raise_error NameError,
-                                                                                       %r{uninitialized constant (Puppet::Transport|TestTarget)}
+          expect { described_class.connect(name, { host: 'example.com' }) }.to raise_error NameError,
+                                                                                           %r{uninitialized constant (Puppet::Transport|TestTarget)}
         end
       end
 
@@ -214,13 +214,13 @@ RSpec.describe Puppet::ResourceApi::Transport do
 
           allow(described_class).to receive(:require).with('puppet/resource_api/puppet_context').and_call_original
           expect(described_class).to receive(:require).with('puppet/transport/test_target')
-          expect(described_class).to receive(:validate).with(name, host: 'example.com')
+          expect(described_class).to receive(:validate).with(name, { host: 'example.com' })
           expect(Puppet::ResourceApi::PuppetContext).to receive(:new).with(kind_of(Puppet::ResourceApi::TransportSchemaDef)).and_return(context)
 
           stub_const('Puppet::Transport::TestTarget', test_target)
-          expect(test_target).to receive(:new).with(context, host: 'example.com')
+          expect(test_target).to receive(:new).with(context, { host: 'example.com' })
 
-          described_class.connect(name, host: 'example.com')
+          described_class.connect(name, { host: 'example.com' })
         end
       end
     end
@@ -303,7 +303,7 @@ RSpec.describe Puppet::ResourceApi::Transport do
 
         it 'cleans the connection_info' do
           expect(schema_def).to receive(:check_schema).with({ host: 'host value', foo: 'foo value' }, kind_of(String)).and_return(nil)
-          expect(schema_def).to receive(:validate).with(host: 'host value', foo: 'foo value').and_return(nil)
+          expect(schema_def).to receive(:validate).with({ host: 'host value', foo: 'foo value' }).and_return(nil)
 
           expect(context).to receive(:debug).with('Discarding bolt metaparameter: query')
           expect(context).to receive(:debug).with('Discarding bolt metaparameter: remote-transport')
@@ -325,7 +325,7 @@ RSpec.describe Puppet::ResourceApi::Transport do
 
         it 'sets defaults in the connection info' do
           expect(schema_def).to receive(:check_schema).with({ host: 'host value', port: 443 }, kind_of(String)).and_return(nil)
-          expect(schema_def).to receive(:validate).with(host: 'host value', port: 443).and_return(nil)
+          expect(schema_def).to receive(:validate).with({ host: 'host value', port: 443 }).and_return(nil)
 
           expect(context).to receive(:debug).with('Using default value for attribute: port, value: 443')
           described_class.send :validate, 'validate', host: 'host value'


### PR DESCRIPTION
This commit updates the versions of Ruby and Puppet that rspec tests run on to include Ruby 3.2 and Puppet 8.