### PR TITLE
(maint) Don't require git

### DIFF
--- a/puppet-resource_api.gemspec
+++ b/puppet-resource_api.gemspec
@@ -12,14 +12,13 @@ Gem::Specification.new do |spec|
   spec.summary       = 'This library provides a simple way to write new native resources for puppet.'
   spec.homepage      = 'https://github.com/puppetlabs/puppet-resource_api'
 
-  # on out internal jenkins, there is no git, but since it is a clean machine, we don't need to worry about anything else
-  spec.files         = if system('git --help > /dev/null')
-                         `git ls-files -z`.split("\x0")
-                       else
-                         Dir.glob('**/*')
-                       end.select do |f|
-                         f.match(%r{^(lib|docs|(CHANGELOG|CONTRIBUTING|README)\.md|LICENSE|NOTICE|puppet-resource_api\.gemspec)})
-                       end
+  base = "#{__dir__}#{File::SEPARATOR}"
+  dirs =
+    Dir[File.join(__dir__, 'lib/**/*')] +
+    Dir[File.join(__dir__, 'docs/**/*')]
+  spec.files =
+    dirs.select { |path| File.file?(path) }.map { |path| path.sub(base, '') } +
+    %w[CHANGELOG.md CONTRIBUTING.md README.md LICENSE NOTICE puppet-resource_api.gemspec]
 
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
This preserves the `git ls-files` behavior of only adding files, and not directories, to `spec.files=`. The motivation for this change is we don't have git installed on all of the platforms for which we build puppet-agent packages.

Inspiration for this change was borrowed from facter[1]

https://github.com/puppetlabs/facter/blob/main/facter.gemspec