### PR TITLE
(PA-5641) prefer auto-generated GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@1.67.0
         env:
-          GITHUB_TOKEN: ${{ secrets.PUPPET_RELEASE_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch
           TAG_CONTEXT: branch
           WITH_V: false


### PR DESCRIPTION
There is no need to embed a specific secret token in the project. An action automatically generates a token during its run, and the repository is set to allow tokens read/write permissions.