### PR TITLE
(PA-5641) Change github bump action and release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,15 +15,11 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.67.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEFAULT_BUMP: patch
-          TAG_CONTEXT: branch
-          WITH_V: false
-          # Uncomment this if the tag and version file become out-of-sync and
-          # you need to tag at a specific version.
-          # CUSTOM_TAG:
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          create_annotated_tag: true
+          tag_prefix:
       - name: Build gem
         uses: scarhand/actions-ruby@master
         with:

--- a/lib/puppet/resource_api/version.rb
+++ b/lib/puppet/resource_api/version.rb
@@ -2,6 +2,6 @@
 
 module Puppet
   module ResourceApi
-    VERSION = '1.8.18'
+    VERSION = '1.8.17'
   end
 end


### PR DESCRIPTION
The old github action from anothrNick/github-tag-action only used lightweight tags; this caused compatibility problems with the way puppetlabs-jenkins used annotated tags. In order to keep the tags consistent, this commit uses mathieudutour/github-tag-action which supports annotated tags. Since the previous attempt to bump skipped the pre-bumped version, that old tag is still available and can be used to synchronize the version in code and in tag.