### PR TITLE
(PA-5803) Update Checkout GitHub Action

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Mend Monitor
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
       - name: Build gem

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -24,7 +24,7 @@ jobs:
       PUPPET_GEM_VERSION: ~> ${{ matrix.cfg.puppet_version }}
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Ruby version ${{ matrix.cfg.ruby }}
@@ -53,7 +53,7 @@ jobs:
       PUPPET_GEM_VERSION: ~> ${{ matrix.cfg.puppet_version }}
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Ruby version ${{ matrix.cfg.ruby }}

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,8 @@ end
 # specific Puppet gem that includes libffi. To work around these issues, we have a separate "integration" group that we include when
 # testing Puppet 8 / Ruby 3.2 on Windows. See PA-5406 for more.
 group :integration do
-  gem 'ffi'
+  # Pin due to an issue with FFI, Windows, and Facter. See FACT-3434
+  gem 'ffi', '1.15.5'
 end
 
 # Find a location or specific version for a gem. place_or_version can be a


### PR DESCRIPTION
The Checkout GitHub Action v3 uses Node 16, which hit end-of-life on September 11, 2023.

This commit updates all instances of the Checkout Action from v3 to v4.