### PR TITLE
(CAT-1533) Set DevX as primary owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
-# Set the networking team as the main owners of the module
-*       @puppetlabs/phoenix
+# Set the DevX team as the primary owners of the Tool
+* @puppetlabs/devx 
+* @puppetlabs/phoenix


### PR DESCRIPTION
DevX team has taken primary ownership of the resource_api tool. Phoenix left as secondary codeowner as they have a stake in the transport section of the tool.