### PR TITLE
Ensure devx and phoenix codeowners are PR approvers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,2 @@
 # Set the DevX team as the primary owners of the Tool
-* @puppetlabs/devx 
-* @puppetlabs/phoenix
+* @puppetlabs/devx @puppetlabs/phoenix


### PR DESCRIPTION
## Summary

When PRs are raised the CODEOWNERS.md is assessed via regex to determine the allowed approvers. The     CODEOWNERS file uses the last matching pattern for each file. In this case, there are two patterns t    hat match all files, and the last one is "@puppetlabs/phoenix". This is why only the Phoenix team is     being requested for review.  To have both teams requested for review, the regex needs to be in one     line like this: "@puppetlabs/devx @puppetlabs/phoenix". This way, both teams will be automatically r    equested for review when a pull request is opened.                                                  