### PR TITLE
Fix RSpec/DescribedClass.

### DIFF
--- a/spec/puppet/resource_api/transport_spec.rb
+++ b/spec/puppet/resource_api/transport_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Puppet::ResourceApi::Transport do
   describe '#inject_device(name, transport)' do
     let(:device_name) { 'wibble' }
     let(:transport) { instance_double(Puppet::Transport::Wibble, 'transport') }
-    let(:wrapper) { instance_double(Puppet::ResourceApi::Transport::Wrapper, 'wrapper') }
+    let(:wrapper) { instance_double(described_class::Wrapper, 'wrapper') }
 
     before do
       module Puppet::Transport
@@ -251,8 +251,8 @@ RSpec.describe Puppet::ResourceApi::Transport do
 
     context 'when puppet has set_device' do
       it 'wraps the transport and calls set_device within NetworkDevice' do
-        allow(Puppet::ResourceApi::Transport::Wrapper).to receive(:new).with(device_name, transport).and_return(wrapper)
-        expect(Puppet::ResourceApi::Transport::Wrapper).to receive(:new).with(device_name, transport)
+        allow(described_class::Wrapper).to receive(:new).with(device_name, transport).and_return(wrapper)
+        expect(described_class::Wrapper).to receive(:new).with(device_name, transport)
         allow(Puppet::Util::NetworkDevice).to receive(:respond_to?).with(:set_device).and_return(true)
         expect(Puppet::Util::NetworkDevice).to receive(:set_device).with(device_name, wrapper)
 
@@ -262,8 +262,8 @@ RSpec.describe Puppet::ResourceApi::Transport do
 
     context 'when puppet does not have set_device' do
       it 'wraps the transport and sets it as current in NetworkDevice' do
-        allow(Puppet::ResourceApi::Transport::Wrapper).to receive(:new).with(device_name, transport).and_return(wrapper)
-        expect(Puppet::ResourceApi::Transport::Wrapper).to receive(:new).with(device_name, transport)
+        allow(described_class::Wrapper).to receive(:new).with(device_name, transport).and_return(wrapper)
+        expect(described_class::Wrapper).to receive(:new).with(device_name, transport)
         allow(Puppet::Util::NetworkDevice).to receive(:respond_to?).with(:set_device).and_return(false)
         expect(Puppet::Util::NetworkDevice).to receive(:respond_to?).with(:set_device)
 

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Puppet::ResourceApi do
   end
 
   it 'has a version number' do
-    expect(Puppet::ResourceApi::VERSION).not_to be nil
+    expect(described_class::VERSION).not_to be nil
   end
 
   context 'when registering a minimal type' do
@@ -1482,7 +1482,7 @@ RSpec.describe Puppet::ResourceApi do
 
       before do
         allow(Puppet::Util::NetworkDevice).to receive(:current).with(no_args).and_return(transport)
-        allow(transport).to receive(:is_a?).with(Puppet::ResourceApi::Transport::Wrapper).and_return(true)
+        allow(transport).to receive(:is_a?).with(described_class::Transport::Wrapper).and_return(true)
         allow(transport).to receive(:schema).and_return(schema_def)
         allow(schema_def).to receive(:name).and_return(schema_name)
 
@@ -1654,7 +1654,7 @@ RSpec.describe Puppet::ResourceApi do
         type.rsapi_provider_get_cache.clear
 
         allow(type.my_provider).to receive(:get)
-          .with(kind_of(Puppet::ResourceApi::BaseContext))
+          .with(kind_of(described_class::BaseContext))
           .and_return([{ name: 'somename', test_string: 'canonfoo' },
                        { name: 'other', test_string: 'canonbar' }])
       end
@@ -1839,7 +1839,7 @@ RSpec.describe Puppet::ResourceApi do
 
       before do
         allow(type.my_provider).to receive(:get)
-          .with(kind_of(Puppet::ResourceApi::BaseContext))
+          .with(kind_of(described_class::BaseContext))
           .and_return([{ name: 'somename', test_string: 'foo' },
                        { name: 'other', test_string: 'bar' }])
         type.rsapi_provider_get_cache.clear
@@ -2113,7 +2113,7 @@ RSpec.describe Puppet::ResourceApi do
       context 'when a transport is returned by NetworkDevice.current' do
         it 'stores the provider with the the name of the transport' do
           allow(Puppet::Util::NetworkDevice).to receive(:current).and_return(wrapper)
-          allow(wrapper).to receive(:is_a?).with(Puppet::ResourceApi::Transport::Wrapper).and_return(true)
+          allow(wrapper).to receive(:is_a?).with(described_class::Transport::Wrapper).and_return(true)
           allow(wrapper).to receive(:transport).and_return(transport)
           allow(transport).to receive(:class).and_return(Puppet::Transport::Wibble)
 
@@ -2361,7 +2361,7 @@ CODE
     end
 
     it 'calls Puppet::ResourceApi::Transport.register' do
-      expect(Puppet::ResourceApi::Transport).to receive(:register).with(schema)
+      expect(described_class::Transport).to receive(:register).with(schema)
       described_class.register_transport(schema)
     end
   end


### PR DESCRIPTION
This error appears something like ``RSpec/DescribedClass: Use `described_class` instead of `PDK::Util`.``.  This rule is triggered when the class under test is referenced directly instead of using `described_class`.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
