### PR TITLE
(maint) Update Gemfile to pin rubocop failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ group :tests do
   gem 'rubocop', '~> 1.48.1', require: false
   gem 'rubocop-rspec', '~> 2.19', require: false
   gem 'rubocop-performance', '~> 1.16', require: false
+  gem 'rubocop-factory_bot', '!= 2.26.0', require: false
+  gem 'rubocop-rspec_rails', '!= 2.29.0', require: false
 end
 
 group :development do


### PR DESCRIPTION
Prior to this commit CI was failing due to breaking changes in the new Gem releases: rubocop-factory_bot, rubocop-rspec_rails

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
