### PR TITLE
Fix rubocop errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,8 @@ group :tests do
   # these require special dependencies to have everything load properly
   # rubocop 1.48 supports JRuby 9.3+, which includes coverage for versions we support
   gem 'rubocop', '~> 1.48.1', require: false
-  gem 'rubocop-rspec', '~> 2.19', require: false
-  gem 'rubocop-performance', '~> 1.16', require: false
+  gem 'rubocop-rspec', '~> 2.20.0', require: false
+  gem 'rubocop-performance', '~> 1.17.1', require: false
 end
 
 group :development do


### PR DESCRIPTION
## Summary

Recent rubocop updates broke the resource_api's CI:

```ruby
➜  puppet-resource_api git:(main) bundle exec rubocop
Error: Property AutoCorrect of cop FactoryBot/CreateList is supposed to be a boolean and contextual is not.
+ set +x
➜  puppet-resource_api git:(main) 
```

Although the fix for other repositories was to upgrade rubocop, an upgrade was not possible on this repo because of the `jruby` and `ruby` engine testing.  The solution was to pin the rubocop dependencies to the last working nightly versions:

```ruby
gem 'rubocop', '~> 1.48.1', require: false
gem 'rubocop-rspec', '~> 2.20.0', require: false
gem 'rubocop-performance', '~> 1.17.1', require: false
```

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
