### PR TITLE
(CAT-2113) Update spec_helper version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :tests do
   gem 'simplecov-console'
 
   # the test gems required for module testing
-  gem 'puppetlabs_spec_helper', '~> 3.0'
+  gem 'puppetlabs_spec_helper', '~> 8.0'
   gem 'rspec-puppet'
   gem 'codecov'
   gem 'rake', '~> 13.0'


### PR DESCRIPTION
This commit aims to update the severely outdated spec_helper depencency one version at a time until we reach the latest version.

