### PR TITLE
(MAINT) Add vendor/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /spec/reports/
 /tmp/
 *.gem
+vendor/
 
 # rspec failure tracking
 .rspec_status


### PR DESCRIPTION
Following a failed attempt to run a release_prep workflows, we realised that the vendor/ path was missing in the .gitignore file. This caused the release process to add thousands of files to the commit, which was not the intended behaviour.

