### PR TITLE
Pass attribute name, not symbol, in attribute type validation

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -189,7 +189,7 @@ module Puppet::ResourceApi
 
         definition[:attributes].each do |name, options|
           type = Puppet::ResourceApi::DataTypeHandling.parse_puppet_type(
-            :name,
+            name,
             options[:type]
           )
 


### PR DESCRIPTION
When calling to parse the definition's Puppet data type during resource validation the symbol :name is used instead of the name variable, leading to a confusing/misleading error message in the event of a data type specification error.