### PR TITLE
(packaging) Bump to version '2.0.1' [no-promote]

### DIFF
--- a/lib/puppet/resource_api/version.rb
+++ b/lib/puppet/resource_api/version.rb
@@ -2,6 +2,6 @@
 
 module Puppet
   module ResourceApi
-    VERSION = '2.0.0'
+    VERSION = '2.0.1'
   end
 end


### PR DESCRIPTION
Since puppet-resource_api v2.0.0 was released out of band from a Puppet Core release, it's version needs to be set to the next release, 2.0.1, in preparation for Puppet Core 8.13.0