### PR TITLE
(maint): Add release preparation and release actions for 1.9.x

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,24 +1,16 @@
-name: Tag and release
+name: "Release"
 
 on:
-  push:
-    tags:
-      - '*'
+  workflow_dispatch:
+   inputs:
+    target:
+      description: "The target for the release. This can be a commit sha or a branch."
+      required: false
+      default: "1.9.x"
 
 jobs:
   release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'
-      - name: Build gem
-        uses: scarhand/actions-ruby@master
-        with:
-          args: build *.gemspec
-      - name: Publish gem
-        uses: scarhand/actions-ruby@master
-        env:
-          RUBYGEMS_AUTH_TOKEN: ${{ secrets.RUBYGEMS_JENKINS_GH_ACTIONS_PUSH }}
-        with:
-          args: push *.gem
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_release.yml@main"
+    with:
+      target: "${{ github.event.inputs.target }}"
+    secrets: "inherit"

--- a/.github/workflows/release_prep.yaml
+++ b/.github/workflows/release_prep.yaml
@@ -1,0 +1,20 @@
+name: "Release Prep"
+
+on:
+  workflow_dispatch:
+   inputs:
+    target:
+      description: "The target for the release. This can be a commit sha or a branch."
+      required: false
+      default: "1.9.x"
+    version:
+      description: "Version of gem to be released."
+      required: true
+
+jobs:
+  release_prep:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_release_prep.yml@main"
+    with:
+      target: "${{ github.event.inputs.target }}"
+      version: "${{ github.event.inputs.version }}"
+    secrets: "inherit"


### PR DESCRIPTION
## Summary
Added `release_prep` and `release` Github actions for 1.9.x branch

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
