### PR TITLE
Release prep v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All significant changes to this repo will be summarized in this file.
 
+## [1.9.2](https://github.com/puppetlabs/puppet-resource_api/tree/1.9.2) (2026-05-18)
+
+[Full Changelog](https://github.com/puppetlabs/puppet-resource_api/compare/1.9.1...1.9.2)
+
+**Fixed bugs:**
+
+- \(PA-8346\): Preserve sensitive parameters [\#384](https://github.com/puppetlabs/puppet-resource_api/pull/384) ([joshcooper](https://github.com/joshcooper))
+
 ## [1.9.1](https://github.com/puppetlabs/puppet-resource_api/tree/1.9.1) (2025-12-17)
 
 [Full Changelog](https://github.com/puppetlabs/puppet-resource_api/compare/1.9.0...1.9.1)

--- a/lib/puppet/resource_api/version.rb
+++ b/lib/puppet/resource_api/version.rb
@@ -2,6 +2,6 @@
 
 module Puppet
   module ResourceApi
-    VERSION = '1.9.1'
+    VERSION = '1.9.2'
   end
 end


### PR DESCRIPTION
Release prep for version 1.9.2 of the 1.9.x branch. Check that the CHANGELOG.md and version.rb files have been updated correctly, and that nightlies are green.

## Checklist
- [ ] Changelog contains the right information and matched version.rb
- [ ] 🟢 Nightlies are green
- [ ] Merging into branch 1.9.x
