### PR TITLE
(PA-7812) Only check_schema on resources actually consumed

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -282,7 +282,6 @@ module Puppet::ResourceApi
                   end
 
         fetched.each do |resource_hash|
-          type_definition.check_schema(resource_hash)
           rsapi_provider_get_cache.add(build_title(type_definition, resource_hash), resource_hash)
         end
 
@@ -300,6 +299,7 @@ module Puppet::ResourceApi
         provider(type_definition.name)
 
         rsapi_provider_get.map do |resource_hash|
+          type_definition.check_schema(resource_hash)
           # allow a :title from the provider to override the default
           result = if resource_hash.key? :title
                      new(title: resource_hash[:title])
@@ -317,6 +317,7 @@ module Puppet::ResourceApi
         current_state = self.class.rsapi_provider_get([rsapi_title]).find { |h| namevar_match?(h) }
 
         if current_state
+          type_definition.check_schema(current_state)
           strict_check(current_state)
         else
           current_state = if rsapi_title.is_a? Hash

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -367,6 +367,38 @@ RSpec.describe Puppet::ResourceApi do
           end
         end
       end
+
+      context 'with a provider that returns other, unmanaged resources with schema violations', :agent_test do
+        before do
+          stub_const('Puppet::Provider::TypeCheck', Module.new)
+          stub_const('Puppet::Provider::TypeCheck::TypeCheck', provider_class)
+          Puppet::Type.type(type_name.to_sym).rsapi_provider_get_cache.clear
+        end
+
+        # `get` returns the managed resource (`test`, schema-valid) alongside another
+        # resource (`other`) that the catalog does not manage but which violates the
+        # schema. Only the managed resource should be schema-checked on retrieve.
+        let(:provider_class) do
+          Class.new do
+            def get(_context)
+              [
+                { name: 'test' },
+                { name: 'other', test_string: 15, wibble: 'foo' }
+              ]
+            end
+
+            def set(_context, _changes); end
+          end
+        end
+
+        context 'when strict is :error' do
+          let(:strict_level) { :error }
+
+          it 'does not raise for schema violations in the unmanaged resource' do
+            expect { instance.retrieve }.not_to raise_error
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

In v2.0.0 the Resource API introduced caching of provider `get()` results. As part of that change, `type_definition.check_schema` was moved into the cache-population loop in `rsapi_provider_get`. Combined with the `get()` optimization (PR #306), a single `get(context)` call now fetches **all** resources of a type and caches them — so `check_schema` runs against every resource on the system during an apply, including resources the catalog does not manage.

The result: modules that previously ran fine now error out because an *unrelated, unmanaged* resource returned by `get()` happens to violate the type schema.

## Fix

Restore the pre-2.0.0 semantics — only schema-check the resources that are actually consumed:

- `rsapi_provider_get` only populates the cache (no longer checks schema).
- `instances` checks each resource (this path backs `puppet resource`, which is meant to validate everything it lists).
- `refresh_current_state` checks only the single matched resource (the one being managed).

`SimpleProvider` already performs its own `check_schema` independently, so it is unaffected.

## Testing

- Full unit suite (`bundle exec rake spec:unit`): **1447 examples, 0 failures**.
- Added a regression test: a provider returns the managed resource (valid) alongside an unmanaged resource with schema violations; under `strict: :error`, retrieving the managed resource no longer raises. Confirmed this test **fails without the fix** and **passes with it**.
- Rubocop clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)