### PR TITLE
(PA-8346) Preserve sensitive parameters

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -105,7 +105,7 @@ module Puppet::ResourceApi
         end
 
         attributes[:sensitive_parameters] = sensitives unless sensitives.empty?
-        super(attributes)
+        super
       end
 
       # Override finish method to ensure scope tags (like class names) are properly inherited

--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -104,7 +104,8 @@ module Puppet::ResourceApi
           attributes[:title] = @title if attributes[:title].nil? && !type_definition.namevars.empty?
         end
 
-        super
+        attributes[:sensitive_parameters] = sensitives unless sensitives.empty?
+        super(attributes)
       end
 
       # Override finish method to ensure scope tags (like class names) are properly inherited

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -498,6 +498,33 @@ RSpec.describe Puppet::ResourceApi do
             instance[:secret] = Puppet::Pops::Types::PSensitiveType::Sensitive.new('a new password')
             instance.flush
           end
+
+          it 'marks the sensitive property with sensitive=true so it is excluded from the transaction store' do
+            expect(instance.parameter(:secret).sensitive).to be true
+          end
+        end
+
+        context 'when loading from a Puppet::Resource with no sensitive parameters' do
+          let(:params) { instance_double('Puppet::Resource', 'resource') }
+          let(:provider_instance) { instance_double(provider_class, 'provider_instance') }
+          let(:catalog) { instance_double('Unknown', 'catalog') }
+
+          before(:each) do
+            allow(provider_class).to receive(:new).with(no_args).and_return(provider_instance)
+            allow(provider_instance).to receive(:get).and_return([])
+            allow(params).to receive(:is_a?).with(Puppet::Resource).and_return(true)
+            allow(params).to receive(:title).with(no_args).and_return('a title')
+            allow(params).to receive(:catalog).with(no_args).and_return(catalog)
+            allow(params).to receive(:sensitive_parameters).with(no_args).and_return([])
+            allow(params).to receive(:to_hash).with(no_args)
+                                              .and_return(title: 'test',
+                                                          secret: Puppet::Pops::Types::PSensitiveType::Sensitive.new('a password value'))
+            allow(catalog).to receive(:host_config?).and_return(true)
+          end
+
+          it 'does not mark the property as sensitive' do
+            expect(instance.parameter(:secret).sensitive).not_to be true
+          end
         end
       end
     end

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -509,7 +509,7 @@ RSpec.describe Puppet::ResourceApi do
           let(:provider_instance) { instance_double(provider_class, 'provider_instance') }
           let(:catalog) { instance_double('Unknown', 'catalog') }
 
-          before(:each) do
+          before do
             allow(provider_class).to receive(:new).with(no_args).and_return(provider_instance)
             allow(provider_instance).to receive(:get).and_return([])
             allow(params).to receive(:is_a?).with(Puppet::Resource).and_return(true)


### PR DESCRIPTION
When converting Puppet::Resource to an instance of Puppet::Type, the list of sensitive_parameters was lost. So later Puppet::Parameter#sensitive returned false.

There are multiple Puppet::Resource and Hash conversions taking place between the resource api and puppet:

  1. resource-api calls Puppet::Resource#to_hash (line 78)
  2. resource-api calls Puppet::Type#initialize(Hash) (line 108)
  3. Puppet::Type#initialize calls hash2resource(Hash) returning Puppet::Resource[1]
  4. Puppet::Type#initialize copies sensitive_parameters from Puppet::Resource to self[2]

We have to ensure the list of sensistive_parameters is preserved through this call chain, so that the resulting Puppet::Parameter#sensitive instance variables are set correctly.

[1] https://github.com/puppetlabs/puppet-private/blob/8361be778eb8bdda8b7335a98a4e7d11557f5f68/lib/puppet/type.rb#L2320
[2] https://github.com/puppetlabs/puppet-private/blob/8361be778eb8bdda8b7335a98a4e7d11557f5f68/lib/puppet/type.rb#L2347

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
