### PR TITLE
(PA-8346) Harden sensitive parameter preservation against regressions

### DIFF
--- a/lib/puppet/resource_api.rb
+++ b/lib/puppet/resource_api.rb
@@ -96,6 +96,11 @@ module Puppet::ResourceApi
         # $stderr.puts "B: #{attributes.inspect}"
         attributes = my_provider.canonicalize(context, [attributes])[0] if type_definition.feature?('canonicalize')
 
+        # Re-wrap any sensitive values that canonicalize may have unwrapped
+        sensitives.each do |name|
+          attributes[name] = Puppet::Pops::Types::PSensitiveType::Sensitive.new(attributes[name]) if attributes.key?(name) && !attributes[name].is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+        end
+
         # the `Puppet::Resource::Ral.find` method, when `instances` does not return a match, uses a Hash with a `:name` key to create
         # an "absent" resource. This is often hit by `puppet resource`. This needs to work, even if the namevar is not called `name`.
         # This bit here relies on the default `title_patterns` (see below) to match the title back to the first (and often only) namevar
@@ -104,8 +109,8 @@ module Puppet::ResourceApi
           attributes[:title] = @title if attributes[:title].nil? && !type_definition.namevars.empty?
         end
 
-        attributes[:sensitive_parameters] = sensitives unless sensitives.empty?
-        super
+        super(attributes)
+        set_sensitive_parameters(sensitives) unless sensitives.empty?
       end
 
       # Override finish method to ensure scope tags (like class names) are properly inherited

--- a/spec/puppet/resource_api_spec.rb
+++ b/spec/puppet/resource_api_spec.rb
@@ -526,6 +526,32 @@ RSpec.describe Puppet::ResourceApi do
             expect(instance.parameter(:secret).sensitive).not_to be true
           end
         end
+
+        context 'when loading from a Puppet::Resource with sensitive parameters listed' do
+          let(:params) { instance_double('Puppet::Resource', 'resource') }
+          let(:provider_instance) { instance_double(provider_class, 'provider_instance') }
+          let(:catalog) { instance_double('Unknown', 'catalog') }
+
+          before do
+            allow(provider_class).to receive(:new).with(no_args).and_return(provider_instance)
+            allow(provider_instance).to receive(:get).and_return([])
+            allow(params).to receive(:is_a?).with(Puppet::Resource).and_return(true)
+            allow(params).to receive(:title).with(no_args).and_return('a title')
+            allow(params).to receive(:catalog).with(no_args).and_return(catalog)
+            allow(params).to receive(:sensitive_parameters).with(no_args).and_return([:secret])
+            allow(params).to receive(:to_hash).with(no_args)
+                                              .and_return(title: 'test', secret: 'a password value')
+            allow(catalog).to receive(:host_config?).and_return(true)
+          end
+
+          it 'preserves sensitive_parameters so Puppet::Parameter#sensitive returns true' do
+            expect(instance.parameter(:secret).sensitive).to be true
+          end
+
+          it 're-wraps the unwrapped secret value as Sensitive' do
+            expect(instance[:secret]).to be_a Puppet::Pops::Types::PSensitiveType::Sensitive
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Follow-up to PR #388 which fixed the cleartext leak of sensitive parameters during `Puppet::Resource` → Hash conversion. This PR hardens that fix in three ways:

- **Replace fragile `attributes[:sensitive_parameters]` injection with `set_sensitive_parameters`** — PR #388 injected `:sensitive_parameters` into the attributes hash before `super`, relying on `hash2resource`'s undocumented internal key-deletion to clean up the extra key. This works today but couples to an implementation detail of Puppet core. This PR uses the public `Puppet::Type#set_sensitive_parameters` API after `super` instead, which is both the intended API and resilient to upstream changes in `hash2resource`.

- **Add a re-wrap guard after `canonicalize`** — Providers that implement `canonicalize` receive unwrapped attribute values. If a provider returns a plain string where a `Sensitive`-wrapped value was expected, the sensitive wrapping is silently lost. This PR adds a post-canonicalize re-wrap pass (identical to the existing pre-canonicalize one) so that the `Sensitive` wrapper survives regardless of provider behavior.

- **Add the missing regression test** — PR #388's tests covered the "no sensitive params" case and the Sensitive-wrapping case, but did not test the primary fix path: a `Puppet::Resource` input carrying a non-empty `sensitive_parameters` list with unwrapped values. This PR adds that test, directly asserting `parameter(:secret).sensitive == true` and that the value is re-wrapped as `Sensitive` — the test that would catch a reintroduction of the original bug.

## Test Plan

- [x] Existing specs continue to pass
- [x] New spec `when loading from a Puppet::Resource with sensitive parameters listed` verifies:
  - `parameter(:secret).sensitive` returns `true`
  - The secret value is re-wrapped as `Puppet::Pops::Types::PSensitiveType::Sensitive`

## Related

- Fixes: [PA-8346](https://tickets.puppetlabs.com/browse/PA-8346)
- Follows: #388